### PR TITLE
Fix #1057 missing zosversion in zos.json

### DIFF
--- a/examples/truffle-migrate/zos.json
+++ b/examples/truffle-migrate/zos.json
@@ -1,8 +1,10 @@
 {
+  "zosversion": "2.2",
   "manifestVersion": "2.2",
   "name": "example-truffle-migrate",
   "version": "0.1.0",
   "contracts": {
     "MyContract": "MyContract_v1"
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
Fixes #1057 

According to https://github.com/zeppelinos/zos/issues/1008#issuecomment-503707380 the entry `zosversion` will be renamed to `manifestVersion`. But as long as we go with zos 2.4, this PR is required to  make this example work.
