### PR TITLE
Use Array.isArray instead of lodash.isarray

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -2373,7 +2373,7 @@
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "resolved": false,
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
@@ -3531,7 +3531,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -3655,11 +3655,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.intersection/-/lodash.intersection-4.4.0.tgz",
       "integrity": "sha1-ChG6Yx0OlcI8fy9Mu5ppLtF45wU="
-    },
-    "lodash.isarray": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-4.0.0.tgz",
-      "integrity": "sha1-KspJayjEym1yZxUxNZDALm6jRAM="
     },
     "lodash.isempty": {
       "version": "4.4.0",
@@ -3820,7 +3815,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -4320,7 +4315,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -87,7 +87,6 @@
     "lodash.frompairs": "^4.0.1",
     "lodash.groupby": "^4.6.0",
     "lodash.intersection": "^4.4.0",
-    "lodash.isarray": "^4.0.0",
     "lodash.isempty": "^4.4.0",
     "lodash.isequal": "^4.5.0",
     "lodash.isnil": "^4.0.0",

--- a/packages/cli/src/utils/async.ts
+++ b/packages/cli/src/utils/async.ts
@@ -1,6 +1,5 @@
 import map from 'lodash.map';
 import isEmpty from 'lodash.isempty';
-import isArray from 'lodash.isarray';
 
 export async function allPromisesOrError(
   promisesWithObjects: any[],
@@ -11,7 +10,7 @@ export async function allPromisesOrError(
     let promise;
     let object = null;
     try {
-      if (isArray(item)) {
+      if (Array.isArray(item)) {
         [promise, object] = item;
       } else {
         promise = item;

--- a/packages/lib/package-lock.json
+++ b/packages/lib/package-lock.json
@@ -4446,23 +4446,6 @@
               "requires": {
                 "bn.js": "^4.11.8",
                 "ethereumjs-util": "^6.0.0"
-              },
-              "dependencies": {
-                "ethereumjs-util": {
-                  "version": "6.1.0",
-                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
-                  "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
-                  "dev": true,
-                  "requires": {
-                    "bn.js": "^4.11.0",
-                    "create-hash": "^1.1.2",
-                    "ethjs-util": "0.1.6",
-                    "keccak": "^1.0.2",
-                    "rlp": "^2.0.0",
-                    "safe-buffer": "^5.1.1",
-                    "secp256k1": "^3.0.1"
-                  }
-                }
               }
             },
             "ethereumjs-block": {
@@ -8056,23 +8039,6 @@
               "requires": {
                 "bn.js": "^4.11.8",
                 "ethereumjs-util": "^6.0.0"
-              },
-              "dependencies": {
-                "ethereumjs-util": {
-                  "version": "6.1.0",
-                  "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
-                  "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
-                  "dev": true,
-                  "requires": {
-                    "bn.js": "^4.11.0",
-                    "create-hash": "^1.1.2",
-                    "ethjs-util": "0.1.6",
-                    "keccak": "^1.0.2",
-                    "rlp": "^2.0.0",
-                    "safe-buffer": "^5.1.1",
-                    "secp256k1": "^3.0.1"
-                  }
-                }
               }
             },
             "ethereumjs-block": {
@@ -9385,11 +9351,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.invertby/-/lodash.invertby-4.7.0.tgz",
       "integrity": "sha1-zeu2zUlCqmuN8sdL4cXZSGgnGLA="
-    },
-    "lodash.isarray": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-4.0.0.tgz",
-      "integrity": "sha1-KspJayjEym1yZxUxNZDALm6jRAM="
     },
     "lodash.isempty": {
       "version": "4.4.0",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -69,7 +69,6 @@
     "lodash.flatten": "^4.4.0",
     "lodash.includes": "^4.3.0",
     "lodash.invertby": "^4.7.0",
-    "lodash.isarray": "^4.0.0",
     "lodash.isempty": "^4.4.0",
     "lodash.isequal": "^4.5.0",
     "lodash.isstring": "^4.0.1",

--- a/packages/lib/src/utils/Semver.ts
+++ b/packages/lib/src/utils/Semver.ts
@@ -1,7 +1,5 @@
 import semver from 'semver';
 import isString from 'lodash.isstring';
-import isArray from 'lodash.isarray';
-
 import util from 'util';
 
 // TS-TODO: use typed SemVer dependency, some of these methods may actually
@@ -15,7 +13,7 @@ export function toSemanticVersion(version: string | RawSemanticVersion): Semanti
     const semanticVersion: any = semver.parse(version as string);
     if (!semanticVersion) throw Error(`Cannot parse version identifier ${version}`);
     return [semanticVersion.major, semanticVersion.minor, semanticVersion.patch];
-  } else if (isArray(version) && version.length === 3) {
+  } else if (Array.isArray(version) && version.length === 3) {
     version = (version as RawSemanticVersion).map(Number) as [number, number, number];
     const semverGenericArray: RawSemanticVersion = version as RawSemanticVersion;
     const semverTyped: number[] = semverGenericArray.map((x: any) => {
@@ -27,7 +25,7 @@ export function toSemanticVersion(version: string | RawSemanticVersion): Semanti
 
 export function semanticVersionToString(version: string | RawSemanticVersion): string | never {
   if (isString(version)) return version as string;
-  else if (isArray(version)) {
+  else if (Array.isArray(version)) {
     const semverGenericArray: RawSemanticVersion = version as RawSemanticVersion;
     return semverGenericArray.join('.') as string;
   } else throw Error(`Cannot handle version identifier ${util.inspect(version)}`);


### PR DESCRIPTION
Removes `lodash.isarray` (which is deprecated) from both packages, and gets rid of this warning when installing the sdk:
![image](https://user-images.githubusercontent.com/3752824/61545327-93165a80-aa1d-11e9-8d81-6de89388591c.png)
