### PR TITLE
Show `oz` alias in openzeppelin cmd description

### DIFF
--- a/packages/cli/src/bin/program.ts
+++ b/packages/cli/src/bin/program.ts
@@ -30,9 +30,7 @@ commandsList = commandsList.filter(c => c.name !== 'status');
 const maxLength: number = Math.max(...commandsList.map(command => command.signature.length));
 
 program
-  .name('openzeppelin')
-  .alias('oz')
-  .alias('zos')
+  .name('openzeppelin|oz')
   .usage('<command> [options]')
   .description(`where <command> is one of: ${commandsList.map(c => c.name).join(', ')}`)
   .version(version, '--version')


### PR DESCRIPTION
Fixes https://github.com/OpenZeppelin/openzeppelin-sdk/issues/1120. Seems that the commander `alias` won't work as expected for the `openzeppelin` command. I added an `oz` into the command name so it looks exactly as how commander shows aliases:

![image](https://user-images.githubusercontent.com/3752824/61547242-5e0c0700-aa21-11e9-9212-318102407c40.png)

`zos upgrade --help` for reference:

![image](https://user-images.githubusercontent.com/3752824/61547271-6a905f80-aa21-11e9-898b-793bb1d2c1d7.png)

I `npm pack`ed it and works as expected!