### PR TITLE
Fix docsite links and ethereum package reference in link command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Run `openzeppelin --help` for more details about thes and all the other function
 OpenZeppelin CLI.
 
 The
-[OpenZeppelin SDK documentation](https://docs.openzeppelin.com/sdk/2.4)
+[OpenZeppelin SDK documentation](https://docs.openzeppelin.com/sdk/2.5)
 explains how to build a project using our platform, how to upgrade contracts,
 how to share packages for other projects to reuse, how to vouch for the quality
 of a package, how to use the JavaScript libraries to operate the project, and

--- a/packages/cli/src/commands/link.ts
+++ b/packages/cli/src/commands/link.ts
@@ -25,7 +25,7 @@ async function action(dependencies: string[], options: any): Promise<void> {
   const args = { dependencies };
   const props = getCommandProps();
   const defaults = {
-    dependencies: [await Dependency.fetchVersionFromNpm('openzeppelin-eth')],
+    dependencies: [await Dependency.fetchVersionFromNpm('@openzeppelin/contracts-ethereum-package')],
   };
   const prompted = await promptIfNeeded({ args, props, defaults }, interactive);
 

--- a/packages/cli/src/interface/ValidationLogger.ts
+++ b/packages/cli/src/interface/ValidationLogger.ts
@@ -11,7 +11,7 @@ import {
 } from '@openzeppelin/upgrades';
 import { ContractInterface } from '../models/files/NetworkFile';
 
-const DOCS_HOME = 'https://docs.zeppelinos.org/docs';
+const DOCS_HOME = 'https://docs.openzeppelin.com/sdk/2.5';
 const DANGEROUS_OPERATIONS_LINK = `${DOCS_HOME}/writing_contracts.html#potentially-unsafe-operations`;
 const AVOID_INITIAL_VALUES_LINK = `${DOCS_HOME}/writing_contracts.html#avoid-initial-values-in-fields-declarations`;
 const INITIALIZERS_LINK = `${DOCS_HOME}/writing_contracts.html#initializers`;

--- a/packages/cli/src/models/files/ManifestVersion.ts
+++ b/packages/cli/src/models/files/ManifestVersion.ts
@@ -10,11 +10,11 @@ export function checkVersion(version: string, where: any): void | never {
   if (version === MANIFEST_VERSION) return;
   else if (isUndefined(version)) {
     throw Error(
-      `Manifest version identifier not found in ${where}. This means the project was built with an older version of ${OPEN_ZEPPELIN} (1.x), and needs to be upgraded. Please refer to the documentation at https://docs.zeppelinos.org for more info.`,
+      `Manifest version identifier not found in ${where}. This means the project was built with an older version of ${OPEN_ZEPPELIN} (1.x), and needs to be upgraded. Please refer to the documentation at https://docs.openzeppelin.comfor more info.`,
     );
   } else if (!isCurrentMajor(version) || (!isCurrentMinor(version) && !isUndefinedMinor(version))) {
     throw Error(
-      `Unrecognized manifest version identifier ${version} found in ${where}. This means the project was built with an unknown version of ${OPEN_ZEPPELIN}. Please refer to the documentation at https://docs.zeppelinos.org for more info.`,
+      `Unrecognized manifest version identifier ${version} found in ${where}. This means the project was built with an unknown version of ${OPEN_ZEPPELIN}. Please refer to the documentation at https://docs.openzeppelin.com/sdk for more info.`,
     );
   }
 }

--- a/packages/cli/src/models/files/ManifestVersion.ts
+++ b/packages/cli/src/models/files/ManifestVersion.ts
@@ -10,7 +10,7 @@ export function checkVersion(version: string, where: any): void | never {
   if (version === MANIFEST_VERSION) return;
   else if (isUndefined(version)) {
     throw Error(
-      `Manifest version identifier not found in ${where}. This means the project was built with an older version of ${OPEN_ZEPPELIN} (1.x), and needs to be upgraded. Please refer to the documentation at https://docs.openzeppelin.comfor more info.`,
+      `Manifest version identifier not found in ${where}. This means the project was built with an older version of ${OPEN_ZEPPELIN} (1.x), and needs to be upgraded. Please refer to the documentation at https://docs.openzeppelin.com for more info.`,
     );
   } else if (!isCurrentMajor(version) || (!isCurrentMinor(version) && !isUndefinedMinor(version))) {
     throw Error(

--- a/packages/cli/src/models/local/KitController.ts
+++ b/packages/cli/src/models/local/KitController.ts
@@ -79,7 +79,7 @@ export default class KitController {
       if (config.manifestVersion !== MANIFEST_VERSION) {
         throw new Error(`Unrecognized kit version identifier ${config.manifestVersion}.
           This means the kit was built with an unknown version of openzeppelin.
-          Please refer to the documentation at https://docs.zeppelinos.org for more info.`);
+          Please refer to the documentation at https://docs.openzeppelin.com/sdk for more info.`);
       }
       return config;
     } catch (e) {


### PR DESCRIPTION
Note that the default will not properly work until we rename and publish `openzeppelin-eth` as `@openzeppelin/contracts-ethereum-package`.