### PR TITLE
Get dependency version with caret

### DIFF
--- a/packages/cli/src/models/dependency/Dependency.ts
+++ b/packages/cli/src/models/dependency/Dependency.ts
@@ -42,9 +42,9 @@ export default class Dependency {
   public static async fetchVersionFromNpm(name: string): Promise<string> {
     const execAsync = promisify(exec);
     try {
-      const { stdout } = await execAsync(`npm view ${name} | grep latest`);
-      const versionMatch = stdout.match(/([0-9]+\.){2}[0-9]+/);
-      return Array.isArray(versionMatch) && versionMatch.length > 0 ? `${name}@${versionMatch[0]}` : name;
+      const { stdout } = await execAsync(`npm view ${name}@latest version`);
+      const version = new semver.SemVer(stdout.trim());
+      return `${name}@^${version.major}.${version.minor}.0`;
     } catch (error) {
       return name;
     }

--- a/packages/cli/test/models/Dependency.test.js
+++ b/packages/cli/test/models/Dependency.test.js
@@ -15,6 +15,18 @@ contract('Dependency', function([_, from]) {
       });
     });
 
+    describe('#fetchVersionFromNpm', function() {
+      it('fetches version from npm', async function () {
+        const actual = await Dependency.fetchVersionFromNpm('zos');
+        actual.should.match(/^zos@\^2\.\d+\.0$/);
+      });
+
+      it('fetches version from npm for org package', async function () {
+        const actual = await Dependency.fetchVersionFromNpm('@openzeppelin/cli');
+        actual.should.match(/^@openzeppelin\/cli@\^\d+\.\d+\.0$/);
+      });
+    });
+
     describe('#fromNameAndVersion', function() {
       describe('with invalid nameAndVersion', function() {
         it('throws error', function() {


### PR DESCRIPTION
Link a dependency version using the caret instead of exact version, and avoid relying on unix specific bash commands.

This allows linking a dependency like `@openzeppelin/contracts-ethereum-package` on version `^2.2.0`. This installs version 2.2.1, but allows using deployments made under version 2.2.0.