### PR TITLE
Validate init params

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,8 +1,10 @@
 import push from './push';
 import init from '../scripts/init';
+import semver from 'semver';
 import { promptIfNeeded, InquirerQuestions } from '../prompts/prompt';
 import { FileSystem } from '@openzeppelin/upgrades';
 import ProjectFile from '../models/files/ProjectFile';
+import { notEmpty } from '../prompts/validators';
 
 const name = 'init';
 const signature = `${name} [project-name] [version]`;
@@ -26,7 +28,7 @@ async function action(projectName: string, version: string, options: any): Promi
 
   const args = { name: projectName, version };
   const props = getCommandProps();
-  const defaults = FileSystem.parseJsonIfExists('package.json') || {};
+  const defaults = FileSystem.parseJsonIfExists('package.json') || { version: '1.0.0' };
   const prompted = await promptIfNeeded({ args, defaults, props }, interactive);
 
   const dependencies = link ? link.split(',') : [];
@@ -50,10 +52,15 @@ function getCommandProps(): InquirerQuestions {
     name: {
       message: 'Welcome to the OpenZeppelin SDK! Choose a name for your project',
       type: 'input',
+      validate: notEmpty
     },
     version: {
       message: 'Initial project version',
       type: 'input',
+      validate: input => {
+        if (semver.parse(input)) return true;
+        return `Invalid semantic version: ${input}`;
+      }
     },
   };
 }

--- a/packages/cli/src/prompts/prompt.ts
+++ b/packages/cli/src/prompts/prompt.ts
@@ -30,6 +30,7 @@ interface InquirerQuestion {
   when?: (answers: { [key: string]: any }) => boolean;
   transformer?: (value: string, answers: { [key: string]: any }) => string;
   normalize?: (input?: any) => any;
+  validate?: (input?: any) => boolean | string;
 }
 
 interface InquirerAnswer {

--- a/packages/cli/src/prompts/validators.ts
+++ b/packages/cli/src/prompts/validators.ts
@@ -1,0 +1,4 @@
+export function notEmpty(input) {
+  if (input && input.length > 0) return true;
+  return "Please enter a non-empty value";
+}


### PR DESCRIPTION
Validates that name is not empty, and that version is semver compatible. Only on interactive command.

Fixes #1142