### PR TITLE
Add revert message to reverts in ProxyFactory

### DIFF
--- a/packages/lib/contracts/upgradeability/ProxyFactory.sol
+++ b/packages/lib/contracts/upgradeability/ProxyFactory.sol
@@ -30,7 +30,13 @@ contract ProxyFactory {
 
     if(_data.length > 0) {
       (bool success,) = proxy.call(_data);
-      require(success);
+      if (!success) {
+        // revert and provide the revert message.
+        assembly {
+          returndatacopy(0, 0, returndatasize)
+          revert(0, returndatasize)         
+        }
+      }
     }    
   }
 
@@ -86,7 +92,9 @@ contract ProxyFactory {
     assembly {
       addr := create2(0, add(code, 0x20), mload(code), salt)
       if iszero(extcodesize(addr)) {
-        revert(0, 0)
+        // revert and provide the revert message.
+        returndatacopy(0, 0, returndatasize)
+        revert(0, returndatasize)
       }
     }
 


### PR DESCRIPTION
Revert messages can be retrieved from the return buffer and passed along in a few locations.