### PR TITLE
Support private contracts on Quorum

### DIFF
--- a/packages/cli/src/bin/options.ts
+++ b/packages/cli/src/bin/options.ts
@@ -1,6 +1,14 @@
 import program, { Command } from 'commander';
 import { DEFAULT_TX_TIMEOUT } from '../models/network/Session';
 
+function appender(xs?: string[]) {
+  xs = xs || [];
+  return function(x: string) {
+    xs.push(x);
+    return xs;
+  };
+}
+
 program.Command.prototype.withNetworkTimeoutOption = function(): Command {
   return this.option(
     '--timeout <timeout>',
@@ -27,4 +35,8 @@ program.Command.prototype.withNonInteractiveOption = function(): Command {
 
 program.Command.prototype.withSkipCompileOption = function(): Command {
   return this.option('--skip-compile', 'skips contract compilation');
+};
+
+program.Command.prototype.withPrivateForOption = function(): Command {
+  return this.option('--privateFor <key>', 'array of public keys for Quorum networks', appender(), []);
 };

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -34,6 +34,7 @@ const register: (program: any) => any = program =>
     .option('--args <arg1, arg2, ...>', 'provide initialization arguments for your contract if required')
     .option('--force', 'force creation even if contracts have local modifications')
     .option('--minimal', 'creates a cheaper but non-upgradeable instance instead, using a minimal proxy')
+    .withPrivateForOption()
     .withNetworkOptions()
     .withSkipCompileOption()
     .withNonInteractiveOption()

--- a/packages/cli/src/commands/create2.ts
+++ b/packages/cli/src/commands/create2.ts
@@ -36,6 +36,7 @@ const register: (program: any) => any = program =>
       `signature of the request, uses the signer to derive the deployment address (uses the sender to derive deployment address if not set)`,
     )
     .option('--force', 'force creation even if contracts have local modifications')
+    .withPrivateForOption()
     .withNetworkOptions()
     .action(action);
 

--- a/packages/cli/src/commands/freeze.ts
+++ b/packages/cli/src/commands/freeze.ts
@@ -10,6 +10,7 @@ const register: (program: any) => any = program =>
     .command(signature, undefined, { noHelp: true })
     .usage('--network <network> [options]')
     .description(description)
+    .withPrivateForOption()
     .withNetworkOptions()
     .action(action);
 

--- a/packages/cli/src/commands/link.ts
+++ b/packages/cli/src/commands/link.ts
@@ -15,6 +15,7 @@ const register: (program: any) => any = program =>
     .usage('[dependencyName1 ... dependencyNameN] [options]')
     .description(description)
     .option('--no-install', 'skip installing packages dependencies locally')
+    .withPrivateForOption()
     .withPushOptions()
     .withNonInteractiveOption()
     .action(action);

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -13,6 +13,7 @@ const register: (program: any) => any = program =>
     .command(signature, undefined, { noHelp: true })
     .usage('--network <network> [options]')
     .description(description)
+    .withPrivateForOption()
     .withNetworkOptions()
     .withNonInteractiveOption()
     .action(action);
@@ -25,7 +26,7 @@ async function action(options: any): Promise<void> {
   const props = getCommandProps();
 
   const promptedOpts = await promptIfNeeded({ opts, defaults, props }, interactive);
-  const { network, txParams } = await ConfigManager.initNetworkConfiguration(promptedOpts);
+  const { network, txParams } = await ConfigManager.initNetworkConfiguration(Object.assign({}, options, promptedOpts));
   if (!(await hasToMigrateProject(network))) process.exit(0);
 
   await publish({ network, txParams });

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -34,6 +34,7 @@ const register: (program: any) => any = program =>
       '--deploy-proxy-factory',
       "eagerly deploys the project's proxy factory (if not deployed yet on the provided network)",
     )
+    .withPrivateForOption()
     .withNetworkOptions()
     .withNonInteractiveOption()
     .action(commandActions);

--- a/packages/cli/src/commands/set-admin.ts
+++ b/packages/cli/src/commands/set-admin.ts
@@ -26,6 +26,7 @@ const register: (program: any) => any = program =>
     .usage('[alias-or-address] [new-admin-address] --network <network> [options]')
     .description(description)
     .option('--force', 'bypass a manual check')
+    .withPrivateForOption()
     .withNetworkOptions()
     .withNonInteractiveOption()
     .action(action);

--- a/packages/cli/src/commands/unlink.ts
+++ b/packages/cli/src/commands/unlink.ts
@@ -12,6 +12,7 @@ const register: (program: any) => any = program =>
     .command(signature, undefined, { noHelp: true })
     .usage('[dependencyName1... dependencyNameN]')
     .description(description)
+    .withPrivateForOption()
     .withPushOptions()
     .withNonInteractiveOption()
     .action(action);

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -36,6 +36,7 @@ const register: (program: any) => any = program =>
     .option('--args <arg1, arg2, ...>', 'provide initialization arguments for your contract if required')
     .option('--all', 'upgrade all contracts in the application')
     .option('--force', 'force creation even if contracts have local modifications')
+    .withPrivateForOption()
     .withNetworkOptions()
     .withSkipCompileOption()
     .withNonInteractiveOption()

--- a/packages/cli/src/models/config/ConfigManager.ts
+++ b/packages/cli/src/models/config/ConfigManager.ts
@@ -22,7 +22,7 @@ const ConfigManager = {
     root: string = process.cwd(),
   ): Promise<{ network: string; txParams: TxParams } | never> {
     this.initStaticConfiguration(root);
-    const { network: networkName, from, timeout } = Session.getOptions(options, silent);
+    const { network: networkName, from, timeout, privateFor } = Session.getOptions(options, silent);
     Session.setDefaultNetworkIfNeeded(options.network);
     if (!networkName) throw Error('A network name must be provided to execute the requested action.');
 
@@ -38,6 +38,7 @@ const ConfigManager = {
       const txParams = {
         from: ZWeb3.toChecksumAddress(from || artifactDefaults.from || (await ZWeb3.defaultAccount())),
       };
+      if (privateFor && privateFor.length > 0) txParams['privateFor'] = privateFor;
 
       return { network: await ZWeb3.getNetworkName(), txParams };
     } catch (error) {

--- a/packages/cli/src/models/network/Session.ts
+++ b/packages/cli/src/models/network/Session.ts
@@ -18,6 +18,7 @@ interface SessionOptions {
   from?: string;
   timeout?: number;
   expires?: Date;
+  privateFor?: string[];
 }
 
 const Session = {


### PR DESCRIPTION
Example of usage with multiple keys

`oz create --privateFor 8hjg/DR2Wl7h49pqb5IcogHpv0mZHCEfcN21gxSLZGg= --privateFor 7NnTIuQdLroIne8HyafdSWFY2rLboSLWBs+jUaMRNAc= --from 0x7DC05569C749f7F5f5168Af9E167CC56a9C357d5`

Take care that quorum-maker currently support only byzantium EVM, in this case compile contracts before deploying with `oz compile --evm-version byzantium`