### PR TITLE
Allow specifying a branch on unpack command

### DIFF
--- a/packages/cli/src/scripts/unpack.ts
+++ b/packages/cli/src/scripts/unpack.ts
@@ -15,7 +15,8 @@ const nameToRepo = {
 export default async function unpack({ repoOrName }: UnpackParams): Promise<void | never> {
   if (!repoOrName) throw Error('A kit name or GitHub repo must be provided to unpack to the current directory.');
   repoOrName = repoOrName.toLowerCase();
-  if (!repoOrName.includes('/')) {
+
+  if (!repoOrName.includes('/') && !repoOrName.includes('#')) {
     // predefined name has been passed
     // check if it is registered
     if (!nameToRepo.hasOwnProperty(repoOrName)) {
@@ -23,8 +24,14 @@ export default async function unpack({ repoOrName }: UnpackParams): Promise<void
     }
     repoOrName = nameToRepo[repoOrName];
   }
+
+  let branchName = 'stable';
+  if (repoOrName.includes('#')) {
+    [repoOrName, branchName] = repoOrName.split('#', 2);
+  }
+
   const url = `https://github.com/${repoOrName}.git`;
   const controller = new KitController();
-  const config = await controller.verifyRepo(url);
-  await controller.unpack(url, process.cwd(), config);
+  const config = await controller.verifyRepo(url, branchName);
+  await controller.unpack(url, branchName, process.cwd(), config);
 }

--- a/packages/cli/test/scripts/unpack.test.js
+++ b/packages/cli/test/scripts/unpack.test.js
@@ -28,6 +28,7 @@ describe('unpack script', function() {
 
   beforeEach('stub git calls', async function() {
     const git = simpleGit();
+    this.git = git;
     gitMock = sinon.mock(git);
     gitMock.expects('init').once();
     gitMock
@@ -35,8 +36,7 @@ describe('unpack script', function() {
       .once()
       .withExactArgs('origin', url);
     gitMock.expects('fetch');
-    sinon.stub(git, 'pull');
-
+    
     sinon.stub(cache, 'simple-git/promise').returns(git);
 
     sinon.stub(child, 'exec').returns(Promise.resolve());
@@ -59,78 +59,129 @@ describe('unpack script', function() {
     gitMock.restore();
   });
 
-  it('should unpack kit to current directory by name', async function() {
-    await unpack({ repoOrName: 'starter' });
-    gitMock.verify();
+  context('on default branch', function () {
+
+    beforeEach(function () {
+      sinon.stub(this.git, 'pull');
+    });
+
+    it('should unpack kit to current directory by name', async function() {
+      await unpack({ repoOrName: 'starter' });
+      gitMock.verify();
+    });
+
+    it('should unpack kit to current directory by repo', async function() {
+      await unpack({ repoOrName: repo });
+      gitMock.verify();
+    });
+
+    it('should fail with random name', async function() {
+      await unpack({ repoOrName: 'lskdjflkdsj' }).should.be.rejectedWith(/Kit named lskdjflkdsj doesn\'t exist/);
+    });
+
+    it('should fail with random repo', async function() {
+      await unpack({
+        repoOrName: 'lskdjflkdsj/sdlkfjlksjfkl',
+      }).should.be.rejectedWith(/Failed to verify/);
+    });
+
+    it('should fail if no kit name or repo specified', async function() {
+      await unpack({ repoOrName: undefined }).should.be.rejectedWith(/A kit name or GitHub repo must be provided/);
+    });
+
+    it('should fail if there are files inside the directory', async function() {
+      fs.readdir.restore();
+      sinon.stub(fs, 'readdir').returns(Promise.resolve([OPEN_ZEPPELIN_FOLDER, 'random']));
+      await unpack({ repoOrName: repo }).should.be.rejectedWith(
+        `Unable to unpack ${url} in the current directory, as it must be empty.`,
+      );
+    });
+
+    it('should fail with wrong kit version', async function() {
+      axios.get.restore();
+      sinon.stub(axios, 'get').returns(
+        Promise.resolve({
+          data: {
+            ...properConfig,
+            manifestVersion: '9000',
+          },
+        }),
+      );
+      await unpack({ repoOrName: repo }).should.be.rejectedWith(/Unrecognized kit version identifier/);
+    });
+
+    it('should fail with wrong json kit', async function() {
+      axios.get.restore();
+      sinon.stub(axios, 'get').returns(
+        Promise.resolve({
+          data: {
+            hacker: '1337',
+          },
+        }),
+      );
+      await unpack({ repoOrName: repo }).should.be.rejectedWith(/kit.json is not valid/);
+    });
+
+    it('should checkout only the files specified in a config', async function() {
+      gitMock
+        .expects('checkout')
+        .once()
+        .withExactArgs(['origin/stable', '--', 'hello', 'second']);
+      axios.get.restore();
+      sinon.stub(axios, 'get').returns(
+        Promise.resolve({
+          data: {
+            ...properConfig,
+            files: ['hello', 'second'],
+          },
+        }),
+      );
+      await unpack({ repoOrName: 'starter' });
+      gitMock.verify();
+    });
   });
 
-  it('should unpack kit to current directory by repo', async function() {
-    await unpack({ repoOrName: repo });
-    gitMock.verify();
-  });
+  context('on custom branch', function () {
 
-  it('should fail with random name', async function() {
-    await unpack({ repoOrName: 'lskdjflkdsj' }).should.be.rejectedWith(/Kit named lskdjflkdsj doesn\'t exist/);
-  });
+    it('should checkout a specified branch', async function () {
+      gitMock
+        .expects('pull')
+        .once()
+        .withExactArgs('origin', 'feature/foobar');
+      
+      axios.get.restore();    
+      sinon.stub(axios, 'get')
+        .withArgs(url.replace('.git', '/feature/foobar/kit.json').replace('github.com', 'raw.githubusercontent.com'))
+        .returns(
+          Promise.resolve({
+            data: properConfig,
+          }),
+        );
 
-  it('should fail with random repo', async function() {
-    await unpack({
-      repoOrName: 'lskdjflkdsj/sdlkfjlksjfkl',
-    }).should.be.rejectedWith(/Failed to verify/);
-  });
+      await unpack({ repoOrName: 'openzeppelin/starter-kit#feature/foobar' });
+      gitMock.verify();
+    });
 
-  it('should fail if no kit name or repo specified', async function() {
-    await unpack({ repoOrName: undefined }).should.be.rejectedWith(/A kit name or GitHub repo must be provided/);
-  });
+    it('should checkout only files specified in a config from a specified branch', async function () {
+      gitMock
+        .expects('checkout')
+        .once()
+        .withExactArgs(['origin/feature/foobar', '--', 'hello', 'second']);
+      
+      axios.get.restore();    
+      sinon.stub(axios, 'get')
+        .withArgs(url.replace('.git', '/feature/foobar/kit.json').replace('github.com', 'raw.githubusercontent.com'))
+        .returns(
+          Promise.resolve({
+            data: {
+              ...properConfig,
+              files: ['hello', 'second'],
+            }
+          }),
+        );
 
-  it('should fail if there are files inside the directory', async function() {
-    fs.readdir.restore();
-    sinon.stub(fs, 'readdir').returns(Promise.resolve([OPEN_ZEPPELIN_FOLDER, 'random']));
-    await unpack({ repoOrName: repo }).should.be.rejectedWith(
-      `Unable to unpack ${url} in the current directory, as it must be empty.`,
-    );
-  });
-
-  it('should fail with wrong kit version', async function() {
-    axios.get.restore();
-    sinon.stub(axios, 'get').returns(
-      Promise.resolve({
-        data: {
-          ...properConfig,
-          manifestVersion: '9000',
-        },
-      }),
-    );
-    await unpack({ repoOrName: repo }).should.be.rejectedWith(/Unrecognized kit version identifier/);
-  });
-
-  it('should fail with wrong json kit', async function() {
-    axios.get.restore();
-    sinon.stub(axios, 'get').returns(
-      Promise.resolve({
-        data: {
-          hacker: '1337',
-        },
-      }),
-    );
-    await unpack({ repoOrName: repo }).should.be.rejectedWith(/kit.json is not valid/);
-  });
-
-  it('should checkout only the files specified in a config', async function() {
-    gitMock
-      .expects('checkout')
-      .once()
-      .withExactArgs(['origin/stable', '--', 'hello', 'second']);
-    axios.get.restore();
-    sinon.stub(axios, 'get').returns(
-      Promise.resolve({
-        data: {
-          ...properConfig,
-          files: ['hello', 'second'],
-        },
-      }),
-    );
-    await unpack({ repoOrName: 'starter' });
-    gitMock.verify();
+      await unpack({ repoOrName: 'openzeppelin/starter-kit#feature/foobar' });
+      gitMock.verify();
+    });
   });
 });


### PR DESCRIPTION
Supports specifying a specific branch when running oz unpack using the syntax `oz unpack org/repo#branch`. This allows picking a non-stable branch for unpacking a box.