### PR TITLE
Increase post unpack buffer

### DIFF
--- a/packages/cli/src/models/local/KitController.ts
+++ b/packages/cli/src/models/local/KitController.ts
@@ -45,7 +45,7 @@ export default class KitController {
       // always delete .git folder
       await remove(path.join(workingDirPath, '.git'));
       // run kit commands like `npm install`
-      await exec(config.hooks['post-unpack']);
+      await exec(config.hooks['post-unpack'], { maxBuffer: 1024 * 1024 * 100});
       Loggy.succeed('unpack-kit', 'Kit downloaded and unpacked');
 
       Loggy.noSpin(__filename, 'unpack', 'unpack-succeeded', `The kit is ready to use. \n${config.message}`);


### PR DESCRIPTION
Unpacking the starter-kit-gsn yielded an `stderr maxBuffer length exceeded` error due to the verbosity of npm install. This increases the default maxbuffer 100x from its default of 1024 ** 2.