### PR TITLE
A note about --unsafe-perm flag in installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Then, install the OpenZeppelin SDK running:
 npm install --global @openzeppelin/cli
 ```
 
+*Note:* in order to fix `Error: EACCES: permission denied, mkdir '/usr/local/lib/node_modules/@openzeppelin/cli/node_modules/keccak/.node-gyp'` use `--unsafe-perm` flag
+
 ## Usage
 
 We recommend to use the OpenZeppelin SDK through the `openzeppelin sdk` command-line interface.


### PR DESCRIPTION
Fixes https://github.com/OpenZeppelin/openzeppelin-sdk/issues/1199

### Motivation
unable to install @openzeppelin/cli library without `--unsafe-perm` flag

### Changelog
Add a note in README about `--unsafe-perm` flag
