### PR TITLE
Update documentation links in ValidationLogger.ts

### DIFF
--- a/packages/cli/src/interface/ValidationLogger.ts
+++ b/packages/cli/src/interface/ValidationLogger.ts
@@ -12,10 +12,10 @@ import {
 import { ContractInterface } from '../models/files/NetworkFile';
 
 const DOCS_HOME = 'https://docs.openzeppelin.com/sdk/2.5';
-const DANGEROUS_OPERATIONS_LINK = `${DOCS_HOME}/writing_contracts.html#potentially-unsafe-operations`;
-const AVOID_INITIAL_VALUES_LINK = `${DOCS_HOME}/writing_contracts.html#avoid-initial-values-in-fields-declarations`;
-const INITIALIZERS_LINK = `${DOCS_HOME}/writing_contracts.html#initializers`;
-const STORAGE_CHECKS_LINK = `${DOCS_HOME}/writing_contracts.html#modifying-your-contracts`;
+const DANGEROUS_OPERATIONS_LINK = `${DOCS_HOME}/writing-contracts#potentially-unsafe-operations`;
+const AVOID_INITIAL_VALUES_LINK = `${DOCS_HOME}/writing-contracts#avoid-initial-values-in-field-declarations`;
+const INITIALIZERS_LINK = `${DOCS_HOME}/writing-contracts#initializers`;
+const STORAGE_CHECKS_LINK = `${DOCS_HOME}/writing-contracts#modifying-your-contracts`;
 
 export default class ValidationLogger {
   public contract: Contract;


### PR DESCRIPTION
Update documentation links as were resulting in page not found.

Updated links:
https://docs.openzeppelin.com/sdk/2.5/writing-contracts#potentially-unsafe-operations
https://docs.openzeppelin.com/sdk/2.5/writing-contracts#avoid-initial-values-in-field-declarations
https://docs.openzeppelin.com/sdk/2.5/writing-contracts#initializers
https://docs.openzeppelin.com/sdk/2.5/writing-contracts#modifying-your-contracts

Current warnings show invalid links
```
$ npx oz create
Nothing to compile, all contracts are up to date.
? Pick a contract to instantiate ABNMarket
? Pick a network development
✓ Added contract ABNMarket
✓ Deploying @openzeppelin/contracts-ethereum-package dependency to network dev-1566901042319
- Contract ABNMarket has an explicit constructor. Change it to an initializer function. 
See https://docs.openzeppelin.com/sdk/2.5/writing_contracts.html#initializers.
- Contract ABNMarket or one of its ancestors sets an initial value in a field declaration. Consider moving all field initializations to an initializer function. 
See https://docs.openzeppelin.com/sdk/2.5/writing_contracts.html#avoid-initial-values-in-fields-declarations.
✓ Contract ABNMarket deployed
All contracts have been deployed
? Do you want to call a function on the instance after creating it? Yes
? Select which function initialize(_tokenName: string)
? _tokenName (string): ABNMarket
✓ Setting everything up to create contract instances
✓ Instance created at 0xf19A2A01B70519f67ADb309a994Ec8c69A967E8b
0xf19A2A01B70519f67ADb309a994Ec8c69A967E8b
```