### PR TITLE
Avoid showing variable name on prompt message if not available

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -52,7 +52,7 @@ function getCommandProps(): InquirerQuestions {
     name: {
       message: 'Welcome to the OpenZeppelin SDK! Choose a name for your project',
       type: 'input',
-      validate: notEmpty
+      validate: notEmpty,
     },
     version: {
       message: 'Initial project version',
@@ -60,7 +60,7 @@ function getCommandProps(): InquirerQuestions {
       validate: input => {
         if (semver.parse(input)) return true;
         return `Invalid semantic version: ${input}`;
-      }
+      },
     },
   };
 }

--- a/packages/cli/src/models/compiler/solidity/SolidityContractsCompiler.ts
+++ b/packages/cli/src/models/compiler/solidity/SolidityContractsCompiler.ts
@@ -174,9 +174,7 @@ class SolidityContractsCompiler {
     const output = solcOutput.contracts[fileName][contractName];
     const source = solcOutput.sources[fileName];
     fileName = path.basename(fileName);
-    const contract = this.contracts.find(
-      aContract => aContract.fileName === fileName,
-    );
+    const contract = this.contracts.find(aContract => aContract.fileName === fileName);
 
     return {
       fileName,

--- a/packages/cli/src/models/dependency/Dependency.ts
+++ b/packages/cli/src/models/dependency/Dependency.ts
@@ -57,7 +57,9 @@ export default class Dependency {
     const hasDependenciesForDeploy = dependencies.find(
       (depNameAndVersion): any => {
         const dependency = Dependency.fromNameWithVersion(depNameAndVersion);
-        return !(dependency.isDeployedOnNetwork(network) || networkFile.dependencyHasMatchingCustomDeploy(dependency.name));
+        return !(
+          dependency.isDeployedOnNetwork(network) || networkFile.dependencyHasMatchingCustomDeploy(dependency.name)
+        );
       },
     );
 

--- a/packages/cli/src/models/local/KitController.ts
+++ b/packages/cli/src/models/local/KitController.ts
@@ -13,7 +13,12 @@ import child from '../../utils/child';
 const simpleGit = patch('simple-git/promise');
 
 export default class KitController {
-  public async unpack(url: string, branchName: string = 'stable', workingDirPath: string = '', config: KitFile): Promise<void | never> {
+  public async unpack(
+    url: string,
+    branchName: string = 'stable',
+    workingDirPath: string = '',
+    config: KitFile,
+  ): Promise<void | never> {
     if (!url) throw Error('A url must be provided.');
     if (!config) throw Error('A config must be provided.');
 
@@ -45,7 +50,7 @@ export default class KitController {
       // always delete .git folder
       await remove(path.join(workingDirPath, '.git'));
       // run kit commands like `npm install`
-      await exec(config.hooks['post-unpack'], { maxBuffer: 1024 * 1024 * 100});
+      await exec(config.hooks['post-unpack'], { maxBuffer: 1024 * 1024 * 100 });
       Loggy.succeed('unpack-kit', 'Kit downloaded and unpacked');
 
       Loggy.noSpin(__filename, 'unpack', 'unpack-succeeded', `The kit is ready to use. \n${config.message}`);

--- a/packages/cli/src/prompts/method-params.ts
+++ b/packages/cli/src/prompts/method-params.ts
@@ -59,7 +59,7 @@ function getCommandProps(
     return {
       ...accum,
       [arg.name]: {
-        message: `${arg.name} (${arg.type}):`,
+        message: arg.name ? `${arg.name} (${arg.type}):` : `(${arg.type}):`,
         type: 'input',
         when: () => !methodArgs || !methodArgs[index],
         validate: input => {

--- a/packages/cli/src/prompts/prompt.ts
+++ b/packages/cli/src/prompts/prompt.ts
@@ -172,7 +172,7 @@ export function methodsList(
   return contractMethods(contractFullName, constant, projectFile)
     .map(({ name, hasInitializer, inputs, selector }) => {
       const initializable = hasInitializer ? '* ' : '';
-      const args = inputs.map(({ name: inputName, type }) => `${inputName}: ${type}`);
+      const args = inputs.map(({ name: inputName, type }) => (inputName ? `${inputName}: ${type}` : type));
       const label = `${initializable}${name}(${args.join(', ')})`;
 
       return { name: label, value: { name, selector } };

--- a/packages/cli/src/prompts/prompt.ts
+++ b/packages/cli/src/prompts/prompt.ts
@@ -198,7 +198,13 @@ export function argsList(
   const method = contractMethods(contractFullName, constant, projectFile).find(
     ({ name, selector }): any => selector === methodIdentifier || name === methodIdentifier,
   );
-  return method ? method.inputs : [];
+
+  if (method) {
+    return method.inputs.map((input, index) => {
+      return input.name ? input : { ...input, name: `#${index}` };
+    });
+  }
+  return [];
 }
 
 function contractMethods(

--- a/packages/cli/src/prompts/validators.ts
+++ b/packages/cli/src/prompts/validators.ts
@@ -1,4 +1,4 @@
 export function notEmpty(input) {
   if (input && input.length > 0) return true;
-  return "Please enter a non-empty value";
+  return 'Please enter a non-empty value';
 }

--- a/packages/cli/test/mocks/mock-stdlib/contracts/GreeterImpl.sol
+++ b/packages/cli/test/mocks/mock-stdlib/contracts/GreeterImpl.sol
@@ -4,6 +4,8 @@ import "./GreeterLib.sol";
 
 contract GreeterImpl {
   using GreeterLib for string;
+
+  mapping(uint256 => string) public greetings;
   event Greeting(string greeting);
 
   function greet(string memory who) public {

--- a/packages/cli/test/prompts/prompt.test.js
+++ b/packages/cli/test/prompts/prompt.test.js
@@ -11,13 +11,7 @@ import { ContractMethodMutability as Mutability } from '@openzeppelin/upgrades';
 import ContractManager from '../../src/models/local/ContractManager';
 import ConfigManager from '../../src/models/config/ConfigManager';
 import ProjectFile from '../../src/models/files/ProjectFile';
-import {
-  promptIfNeeded,
-  contractsList,
-  networksList,
-  methodsList,
-  argsList,
-} from '../../src/prompts/prompt';
+import { promptIfNeeded, contractsList, networksList, methodsList, argsList } from '../../src/prompts/prompt';
 
 describe('prompt', function() {
   describe('functions', function() {
@@ -41,10 +35,7 @@ describe('prompt', function() {
           context('without defaults', function() {
             it('prompts for the missing argument', async function() {
               const args = { foo: 'jango', bar: undefined };
-              await promptIfNeeded(
-                { args, props: this.props },
-                this.interactive,
-              );
+              await promptIfNeeded({ args, props: this.props }, this.interactive);
               const questions = this.stub.getCall(0).args[0];
 
               questions.should.have.lengthOf(1);
@@ -57,10 +48,7 @@ describe('prompt', function() {
             it('prompts for the missing argument', async function() {
               const args = { foo: undefined, bar: undefined };
               const defaults = { foo: 'foo' };
-              await promptIfNeeded(
-                { args, defaults, props: this.props },
-                this.interactive,
-              );
+              await promptIfNeeded({ args, defaults, props: this.props }, this.interactive);
               const questions = this.stub.getCall(0).args[0];
 
               questions.should.have.lengthOf(2);
@@ -93,33 +81,28 @@ describe('prompt', function() {
         });
       });
 
-      context(
-        'with DISABLE_INTERACTIVITY environment variable set',
-        function() {
-          beforeEach('disable interactivity', function() {
-            prompt.DISABLE_INTERACTIVITY = true;
-          });
+      context('with DISABLE_INTERACTIVITY environment variable set', function() {
+        beforeEach('disable interactivity', function() {
+          prompt.DISABLE_INTERACTIVITY = true;
+        });
 
-          afterEach('enable interactivity', function() {
-            prompt.DISABLE_INTERACTIVITY = false;
-          });
+        afterEach('enable interactivity', function() {
+          prompt.DISABLE_INTERACTIVITY = false;
+        });
 
-          it('does not prompt', async function() {
-            const args = { foo: undefined, bar: undefined };
-            await promptIfNeeded({ args, props: this.props }, this.interactive);
-            const call = this.stub.getCall(0);
+        it('does not prompt', async function() {
+          const args = { foo: undefined, bar: undefined };
+          await promptIfNeeded({ args, props: this.props }, this.interactive);
+          const call = this.stub.getCall(0);
 
-            (call === null).should.be.true;
-          });
-        },
-      );
+          (call === null).should.be.true;
+        });
+      });
     });
 
     describe('#networksList', function() {
       beforeEach('set stub and initialize', function() {
-        this.stub = sinon
-          .stub(ConfigManager, 'getNetworkNamesFromConfig')
-          .returns(['Meinet', 'Rinkebay']);
+        this.stub = sinon.stub(ConfigManager, 'getNetworkNamesFromConfig').returns(['Meinet', 'Rinkebay']);
       });
 
       afterEach('restore stub', function() {
@@ -129,9 +112,7 @@ describe('prompt', function() {
       it('returns an object with correct keys and values', function() {
         const networkList = networksList('network', 'listy');
         networkList.should.be.an('object');
-        networkList.network.should.be
-          .an('object')
-          .that.has.all.keys('type', 'message', 'choices');
+        networkList.network.should.be.an('object').that.has.all.keys('type', 'message', 'choices');
         networkList.network.type.should.eq('listy');
         networkList.network.message.should.eq('Pick a network');
         networkList.network.choices.should.have.members(['Meinet', 'Rinkebay']);
@@ -140,15 +121,9 @@ describe('prompt', function() {
 
     describe('#contractsList', function() {
       beforeEach('set stub and initialize', function() {
-        sinon
-          .stub(ContractManager.prototype, 'getContractNames')
-          .returns(['Foo', 'Bar', 'Buz']);
-        sinon
-          .stub(ProjectFile.prototype, 'dependencies')
-          .get(() => ({ 'mock-stdlib': '1.1.0' }));
-        sinon
-          .stub(ProjectFile.prototype, 'contracts')
-          .get(() => ({ Foo: 'Foo', BarAlias: 'Bar' }));
+        sinon.stub(ContractManager.prototype, 'getContractNames').returns(['Foo', 'Bar', 'Buz']);
+        sinon.stub(ProjectFile.prototype, 'dependencies').get(() => ({ 'mock-stdlib': '1.1.0' }));
+        sinon.stub(ProjectFile.prototype, 'contracts').get(() => ({ Foo: 'Foo', BarAlias: 'Bar' }));
       });
 
       afterEach('restore stub', function() {
@@ -157,40 +132,22 @@ describe('prompt', function() {
 
       context('when looking for built contracts', function() {
         it('returns an object with correct keys and values from build dir', function() {
-          const contracts = contractsList(
-            'keyName',
-            'Im a message',
-            'listy',
-            'built',
-          );
+          const contracts = contractsList('keyName', 'Im a message', 'listy', 'built');
 
           contracts.should.be.an('object');
-          contracts.keyName.should.be
-            .an('object')
-            .that.has.all.keys('type', 'message', 'choices');
+          contracts.keyName.should.be.an('object').that.has.all.keys('type', 'message', 'choices');
           contracts.keyName.type.should.eq('listy');
           contracts.keyName.message.should.eq('Im a message');
-          contracts.keyName.choices.should.include.members([
-            'Foo',
-            'Bar',
-            'Buz',
-          ]);
+          contracts.keyName.choices.should.include.members(['Foo', 'Bar', 'Buz']);
         });
       });
 
       context('when looking for added contracts', function() {
         it('returns an object with correct keys and values from local', function() {
-          const contracts = contractsList(
-            'keyName',
-            'Im a message',
-            'listy',
-            'added',
-          );
+          const contracts = contractsList('keyName', 'Im a message', 'listy', 'added');
 
           contracts.should.be.an('object');
-          contracts.keyName.should.be
-            .an('object')
-            .that.has.all.keys('type', 'message', 'choices');
+          contracts.keyName.should.be.an('object').that.has.all.keys('type', 'message', 'choices');
           contracts.keyName.type.should.eq('listy');
           contracts.keyName.message.should.eq('Im a message');
           contracts.keyName.choices.should.not.deep.include({
@@ -206,12 +163,7 @@ describe('prompt', function() {
 
       context('when looking for not yet added but built contracts', function() {
         it('returns an object with not added contracts', function() {
-          const contracts = contractsList(
-            'keyName',
-            'Im a message',
-            'listy',
-            'notAdded',
-          );
+          const contracts = contractsList('keyName', 'Im a message', 'listy', 'notAdded');
           contracts.keyName.choices.should.include.members(['Bar', 'Buz']);
           contracts.keyName.choices.should.not.include('Foo');
         });
@@ -219,86 +171,62 @@ describe('prompt', function() {
 
       context('when looking for both built and package contracts', function() {
         it('returns an object with all correct keys and values', function() {
-          const contracts = contractsList(
-            'keyName',
-            'Im a message',
-            'listy',
-            'all',
-          );
+          const contracts = contractsList('keyName', 'Im a message', 'listy', 'all');
 
           contracts.should.be.an('object');
-          contracts.keyName.should.be
-            .an('object')
-            .that.has.all.keys('type', 'message', 'choices');
+          contracts.keyName.should.be.an('object').that.has.all.keys('type', 'message', 'choices');
           contracts.keyName.type.should.eq('listy');
           contracts.keyName.message.should.eq('Im a message');
-          contracts.keyName.choices.should.include.members([
-            'Foo',
-            'Bar',
-            'mock-stdlib/Foo',
-            'mock-stdlib/BarAlias',
-          ]);
+          contracts.keyName.choices.should.include.members(['Foo', 'Bar', 'mock-stdlib/Foo', 'mock-stdlib/BarAlias']);
         });
       });
     });
 
     describe('#methodsList', function() {
       beforeEach('initialize projectFile', function() {
-        this.projectFile = new ProjectFile(
-          'test/mocks/mock-stdlib-2/zos.json',
-        );
+        this.projectFile = new ProjectFile('test/mocks/mock-stdlib-2/zos.json');
       });
 
-      context(
-        'when providing an unexistent contract in the package',
-        function() {
-          it('returns an empty array of methods', function() {
-            const methods = methodsList(
-              'Foobar',
-              Mutability.NotConstant,
-              this.projectFile,
-            );
-            methods.should.be.an('array').that.is.empty;
-          });
-        },
-      );
+      context('when providing an unexistent contract in the package', function() {
+        it('returns an empty array of methods', function() {
+          const methods = methodsList('Foobar', Mutability.NotConstant, this.projectFile);
+          methods.should.be.an('array').that.is.empty;
+        });
+      });
 
       context('when providing an existent contract', function() {
         context('when querying constant methods', function() {
+          beforeEach(function() {
+            this.methods = methodsList('Greeter', Mutability.Constant, this.projectFile);
+          });
+
           it('returns an array of constant methods', function() {
-            const methods = methodsList(
-              'Greeter',
-              Mutability.Constant,
-              this.projectFile,
-            );
-            methods.should.be.an('array');
-            methods.should.have.lengthOf(2);
-            methods[0].should.be
-              .an('object')
-              .that.has.all.keys('name', 'value');
-            methods[0].name.should.eq('greeting(who: string)');
-            methods[0].value.should.be
-              .an('object')
-              .that.has.all.keys('name', 'selector');
+            this.methods.should.be.an('array');
+            this.methods.should.have.lengthOf(3);
+            this.methods[0].should.be.an('object').that.has.all.keys('name', 'value');
+            this.methods[1].should.be.an('object').that.has.all.keys('name', 'value');
+            this.methods[2].should.be.an('object').that.has.all.keys('name', 'value');
+          });
+
+          it('avoids showing paramater name if not present', function() {
+            this.methods[0].name.should.eq('greetings(uint256)');
+            this.methods[0].value.should.be.an('object').that.has.all.keys('name', 'selector');
+          });
+
+          it('shows paramater name if present', function() {
+            this.methods[1].name.should.eq('greeting(who: string)');
+            this.methods[1].value.should.be.an('object').that.has.all.keys('name', 'selector');
           });
         });
 
         context('when querying non-constant methods', function() {
           it('returns an array of non-constant methods', function() {
-            const methods = methodsList(
-              'Greeter',
-              Mutability.NotConstant,
-              this.projectFile,
-            );
+            const methods = methodsList('Greeter', Mutability.NotConstant, this.projectFile);
             methods.should.be.an('array');
             methods.should.have.lengthOf(1);
-            methods[0].should.be
-              .an('object')
-              .that.has.all.keys('name', 'value');
+            methods[0].should.be.an('object').that.has.all.keys('name', 'value');
             methods[0].name.should.eq('greet(who: string)');
-            methods[0].value.should.be
-              .an('object')
-              .that.has.all.keys('name', 'selector');
+            methods[0].value.should.be.an('object').that.has.all.keys('name', 'selector');
           });
         });
       });
@@ -306,51 +234,38 @@ describe('prompt', function() {
 
     describe('#argsList', function() {
       beforeEach('initialize projectFile', function() {
-        this.projectFile = new ProjectFile(
-          'test/mocks/mock-stdlib-2/zos.json',
-        );
+        this.projectFile = new ProjectFile('test/mocks/mock-stdlib-2/zos.json');
       });
 
-      context(
-        'when providing an unexistent contract in the package',
-        function() {
-          it('returns an empty array', function() {
-            const args = argsList(
-              'Foobar',
-              'foo()',
-              Mutability.NotConstant,
-              this.projectFile,
-            );
-            args.should.be.an('array').that.is.empty;
-          });
-        },
-      );
+      context('when providing an unexistent contract in the package', function() {
+        it('returns an empty array', function() {
+          const args = argsList('Foobar', 'foo()', Mutability.NotConstant, this.projectFile);
+          args.should.be.an('array').that.is.empty;
+        });
+      });
 
-      context(
-        'when providing an existent contract but an existent identifier',
-        function() {
-          it('returns an empty array', function() {
-            const args = argsList(
-              'Greeter',
-              'foo(string)',
-              Mutability.NotConstant,
-              this.projectFile,
-            );
-            args.should.be.an('array').that.is.empty;
-          });
-        },
-      );
+      context('when providing an existent contract but an existent identifier', function() {
+        it('returns an empty array', function() {
+          const args = argsList('Greeter', 'foo(string)', Mutability.NotConstant, this.projectFile);
+          args.should.be.an('array').that.is.empty;
+        });
+      });
 
       context('when providing an existent contract and identifier', function() {
-        it('returns an array of method arguments names', function() {
-          const args = argsList(
-            'Greeter',
-            'greet(string)',
-            Mutability.NotConstant,
-            this.projectFile,
-          );
-          args.should.be.an('array');
-          args[0].should.deep.equal({ name: 'who', type: 'string' });
+        context('when the argument has an explicit name', function() {
+          it('returns an array of method arguments names', function() {
+            const args = argsList('Greeter', 'greet(string)', Mutability.NotConstant, this.projectFile);
+            args.should.be.an('array');
+            args[0].should.deep.equal({ name: 'who', type: 'string' });
+          });
+        });
+
+        context('when the argument has no name', function() {
+          it('returns an array of method arguments names', function() {
+            const args = argsList('Greeter', 'greetings(uint256)', Mutability.Constant, this.projectFile);
+            args.should.be.an('array');
+            args[0].should.deep.equal({ name: '#0', type: 'uint256' });
+          });
         });
       });
     });


### PR DESCRIPTION
Fixes #1209. This PR fixes `oz call`, `oz send-tx`, `oz create` and `oz upgrade` interactive method and method arguments prompts when a contract has:
- A public mapping variable defined (and thus a getter function associated)
- A function that receives parameters without name.

In both cases, we are now showing the function definition without the variable name and a `#0`, `#1`, `#2`, ..., `#n` for each parameter without a name:
![bug](https://user-images.githubusercontent.com/3752824/64718149-07103480-d49c-11e9-9d48-a0f10b3e1d51.gif)
