### PR TITLE
Update public-deploy to include Rinkeby and Kovan

### DIFF
--- a/packages/docs/modules/ROOT/pages/public-deploy.adoc
+++ b/packages/docs/modules/ROOT/pages/public-deploy.adoc
@@ -100,6 +100,14 @@ module.exports = {
       provider: () => new HDWalletProvider(process.env.DEV_MNEMONIC, "https://ropsten.infura.io/v3/" + infuraProjectId),
       networkId: 3,       // Ropsten's id
     },
+    rinkeby: {
+      provider: () => new HDWalletProvider(process.env.DEV_MNEMONIC, "https://rinkeby.infura.io/v3/" + infuraProjectId),
+      networkId: 4,       // Rinkeby's id
+    },
+    kovan: {
+      provider: () => new HDWalletProvider(process.env.DEV_MNEMONIC, "https://kovan.infura.io/v3/" + infuraProjectId),
+      networkId: 42,       // Kovan's id
+    },
   },
 };
 ----


### PR DESCRIPTION
gsn-dapp documentation: https://docs.openzeppelin.com/sdk/2.5/gsn-dapp#moving-to-testnet uses Rinkeby network, so added Rinkeby and Kovan (had issue with default gas limit for Goerli otherwise would have added as well)