### PR TITLE
Implement regular deploys in the CLI

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -11,7 +11,7 @@ import { fromContractFullName } from '../utils/naming';
 import { hasToMigrateProject } from '../prompts/migrations';
 import ConfigManager from '../models/config/ConfigManager';
 import { promptIfNeeded, networksList, contractsList, methodsList, InquirerQuestions } from '../prompts/prompt';
-import promptForMethodParams from '../prompts/method-params';
+import promptForMethodParams, { promptMethods } from '../prompts/method-params';
 import { ProxyType } from '../scripts/interfaces';
 
 interface PropsParams {
@@ -81,6 +81,7 @@ async function action(contractFullName: string, options: any): Promise<void> {
     askForMethodParamsMessage: 'Call a function to initialize the instance after creating it?',
   };
   const { methodName, methodArgs } = await promptForMethodParams(contractFullName, options, additionalOpts);
+  const { methodName: foo } = await promptMethods(contractFullName, options, additionalOpts);
 
   const args = pickBy({
     packageName,

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -20,20 +20,24 @@ interface PropsParams {
   methodArgs?: string[];
 }
 
-const name = 'create';
+const name = 'deploy';
 const signature = `${name} [alias]`;
 const description =
-  'deploys a new upgradeable contract instance. Provide the <alias> you added your contract with, or <package>/<alias> to create a contract from a linked package.';
+  'deploys a new contract instance. Provide the <name> you added your contract with, or <package>/<name> to deploy a contract from a linked package.';
 
 const register: (program: any) => any = program =>
   program
     .command(signature, undefined, { noHelp: true })
+    .alias('create')
     .usage('[alias] --network <network> [options]')
     .description(description)
-    .option('--init [function]', `call function after creating contract. If none is given, 'initialize' will be used`)
+    .option(
+      '--init [function]',
+      `call function after creating an upgradeable instance. If none is given, 'initialize' will be used`,
+    )
     .option('--args <arg1, arg2, ...>', 'provide initialization arguments for your contract if required')
     .option('--force', 'force creation even if contracts have local modifications')
-    .option('--minimal', 'creates a cheaper but non-upgradeable instance instead, using a minimal proxy')
+    .option('--minimal', 'deploys a cheaper but non-upgradeable instance instead, using a minimal proxy')
     .withNetworkOptions()
     .withSkipCompileOption()
     .withNonInteractiveOption()

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -47,20 +47,20 @@ async function commandActions(contractFullName: string, options: any): Promise<v
   const { skipCompile } = options;
   if (!skipCompile) await compile();
 
-  const { network: promptedNewtork, contractFullName: promptedContractFullName } = await promptForCreate(
+  const { network: promptedNetwork, contractFullName: promptedContractFullName } = await promptForCreate(
     contractFullName,
     options,
   );
   const { network, txParams } = await ConfigManager.initNetworkConfiguration({
     ...options,
-    network: promptedNewtork,
+    network: promptedNetwork,
   });
 
   await link.runActionIfNeeded(promptedContractFullName, options);
   await add.runActionIfNeeded(promptedContractFullName, options);
   await push.runActionIfNeeded(promptedContractFullName, network, {
     ...options,
-    network: promptedNewtork,
+    network: promptedNetwork,
     force: true,
   });
 

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -12,6 +12,7 @@ import ProjectFile from '../models/files/ProjectFile';
 import ConfigManager from '../models/config/ConfigManager';
 import { promptIfNeeded, networksList, InquirerQuestions } from '../prompts/prompt';
 import NetworkFile from '../models/files/NetworkFile';
+import ContractManager from '../models/local/ContractManager';
 
 const name = 'push';
 const signature: string = name;
@@ -94,14 +95,16 @@ async function runActionIfNeeded(contractName: string, network: string, options:
   const projectFile = new ProjectFile();
   const networkFile = new NetworkFile(projectFile, network);
   const { contract: contractAlias, package: packageName } = fromContractFullName(contractName);
+  const isUpgradeable = new ContractManager(projectFile).isUpgradeableContract(packageName, contractAlias);
 
   if (interactive) {
     if (
-      force ||
-      (!packageName && !networkFile.hasContract(contractAlias)) ||
-      (packageName && !networkFile.hasDependency(packageName))
+      isUpgradeable &&
+      (force ||
+        (!packageName && !networkFile.hasContract(contractAlias)) ||
+        (packageName && !networkFile.hasDependency(packageName)))
     ) {
-      await action({ ...options, dontExitProcess: true });
+      await action({ ...options, contractAlias, dontExitProcess: true });
     }
   }
 }

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -94,7 +94,7 @@ async function runActionIfRequested(externalOptions: any): Promise<void> {
 }
 
 async function runActionIfNeeded(contractName: string, network: string, options: any): Promise<void> {
-  const { force, interactive, network: promptedNetwork } = options;
+  const { force, interactive } = options;
   const projectFile = new ProjectFile();
   const networkFile = new NetworkFile(projectFile, network);
   const { contract: contractAlias, package: packageName } = fromContractFullName(contractName);

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -52,6 +52,7 @@ async function action(options: any): Promise<void> {
     network: networkInOpts,
     deployProxyAdmin,
     deployProxyFactory,
+    contractAlias,
     interactive,
   } = options;
   const { network: networkInSession, expired } = Session.getNetwork();
@@ -70,7 +71,7 @@ async function action(options: any): Promise<void> {
   });
   const promptDeployDependencies = await promptForDeployDependencies(deployDependencies, network, interactive);
 
-  await push({
+  const pushParams = {
     deployProxyAdmin,
     deployProxyFactory,
     force,
@@ -78,7 +79,9 @@ async function action(options: any): Promise<void> {
     network,
     txParams,
     ...promptDeployDependencies,
-  });
+  };
+
+  await push(contractAlias ? { ...pushParams, contractAlias } : pushParams);
   if (!options.dontExitProcess && process.env.NODE_ENV !== 'test') process.exit(0);
 }
 

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -86,7 +86,6 @@ async function promptForProxies(proxyReference: string, network: string, options
   const args = { pickProxyBy, proxy: proxyReference };
   const props = getCommandProps({ proxyReference, network, all });
   const { pickProxyBy: promptedPickProxyBy, proxy: promptedProxy } = await promptIfNeeded({ args, props }, interactive);
-  console.log('que prompteo', promptedProxy);
 
   return {
     ...promptedProxy,

--- a/packages/cli/src/models/files/NetworkFile.ts
+++ b/packages/cli/src/models/files/NetworkFile.ts
@@ -56,7 +56,9 @@ export interface ProxyInstanceInfo extends CommonInstanceInfo {
   kind: ProxyType;
 }
 
-export interface RegularInstanceInfo extends CommonInstanceInfo {}
+export interface RegularInstanceInfo extends CommonInstanceInfo {
+  kind: ProxyType;
+}
 
 export interface InstanceInfo extends ProxyInstanceInfo, RegularInstanceInfo {}
 

--- a/packages/cli/src/models/local/ContractManager.ts
+++ b/packages/cli/src/models/local/ContractManager.ts
@@ -1,4 +1,4 @@
-import { Contracts, Contract, FileSystem } from '@openzeppelin/upgrades';
+import { Contracts, Contract, ContractAST, FileSystem } from '@openzeppelin/upgrades';
 import Dependency from '../dependency/Dependency';
 import ProjectFile from '../files/ProjectFile';
 import ConfigManager from '../config/ConfigManager';
@@ -49,6 +49,15 @@ export default class ContractManager {
     } else return [];
   }
 
+  public isUpgradeableContract(packageName: string, contractName: string): boolean {
+    const contract = this.getContractClass(packageName, contractName);
+    const contractAst = new ContractAST(contract, null, { nodesFilter: ['ContractDefinition'] });
+
+    return !!contractAst.getContractNode().baseContracts.find(({ baseName }) => {
+      // TODO: take into account only @openzeppelin/upgrades Initializable and Upgradeable contracts
+      return baseName.name === 'Initializable' || baseName.name === 'Upgradeable';
+    });
+  }
   private isLocalContract(contractsDir: string, contract: { sourcePath: string }, root: string): boolean {
     const cwd = root || process.cwd();
     const contractFullPath = path.resolve(cwd, contract.sourcePath);

--- a/packages/cli/src/models/local/ContractManager.ts
+++ b/packages/cli/src/models/local/ContractManager.ts
@@ -68,6 +68,11 @@ export default class ContractManager {
     return contract && contract.bytecode.length <= 2;
   }
 
+  public hasConstructor(packageName: string, contractName: string): boolean {
+    const contract = this.getContractClass(packageName, contractName);
+    return !!contract.schema.abi.find(method => method.type === 'constructor');
+  }
+
   private isLibrary(contract: { [key: string]: any }): boolean {
     return (
       contract &&

--- a/packages/cli/src/models/network/NetworkController.ts
+++ b/packages/cli/src/models/network/NetworkController.ts
@@ -15,6 +15,7 @@ import toPairs from 'lodash.topairs';
 import {
   Contracts,
   Contract,
+  ContractAST,
   Loggy,
   FileSystem as fs,
   Proxy,

--- a/packages/cli/src/prompts/prompt.ts
+++ b/packages/cli/src/prompts/prompt.ts
@@ -13,7 +13,7 @@ import ContractManager from '../models/local/ContractManager';
 import Dependency from '../models/dependency/Dependency';
 import { fromContractFullName, toContractFullName } from '../utils/naming';
 import { ProxyType } from '../scripts/interfaces';
-import NetworkFile, { ProxyInterface } from '../models/files/NetworkFile';
+import NetworkFile, { ProxyInstanceQuery } from '../models/files/NetworkFile';
 
 type ChoicesT = string[] | ({ [key: string]: any });
 
@@ -94,7 +94,7 @@ export function networksList(name: string, type: string, message?: string): { [k
 export function proxiesList(
   pickProxyBy: string,
   network: string,
-  filter?: ProxyInterface,
+  filter?: Partial<ProxyInstanceQuery>,
   projectFile?: ProjectFile,
 ): { [key: string]: any } {
   projectFile = projectFile || new ProjectFile();
@@ -240,7 +240,7 @@ export function proxyInfo(contractInfo: any, network: string): any {
     };
   } else {
     const proxies = networkFile.getProxies(proxyParams);
-    const proxy = proxies[0] || {};
+    const proxy: ProxyInstanceQuery = proxies[0] || {};
     const contractFullName = toContractFullName(proxy.package, proxy.contract);
 
     return {

--- a/packages/cli/src/scripts/create.ts
+++ b/packages/cli/src/scripts/create.ts
@@ -24,8 +24,7 @@ export default async function createProxy({
 
   const controller = new NetworkController(network, txParams, networkFile);
   try {
-    await controller.checkContractDeployed(packageName, contractAlias, !force);
-    const proxy = await controller.createProxy(
+    const instance = await controller.deployInstance(
       packageName,
       contractAlias,
       methodName,
@@ -35,10 +34,10 @@ export default async function createProxy({
       signature,
       kind,
     );
-    stdout(proxy.address);
+    stdout(instance.address);
     controller.writeNetworkPackageIfNeeded();
 
-    return proxy;
+    return instance;
   } catch (error) {
     const cb = () => controller.writeNetworkPackageIfNeeded();
     throw new ScriptError(error, cb);

--- a/packages/cli/src/scripts/interfaces.ts
+++ b/packages/cli/src/scripts/interfaces.ts
@@ -82,6 +82,7 @@ export interface PushParams extends Network {
   deployDependencies?: boolean;
   deployProxyAdmin?: boolean;
   deployProxyFactory?: boolean;
+  contractAlias?: string;
 }
 
 export interface VerifyParams extends Network {

--- a/packages/cli/src/scripts/interfaces.ts
+++ b/packages/cli/src/scripts/interfaces.ts
@@ -37,6 +37,7 @@ interface Proxy extends Network, MethodParams, PackageArgs {
 export enum ProxyType {
   Upgradeable = 'Upgradeable',
   Minimal = 'Minimal',
+  Regular = 'Regular',
 }
 
 export interface CreateParams extends Proxy {

--- a/packages/cli/src/scripts/push.ts
+++ b/packages/cli/src/scripts/push.ts
@@ -11,6 +11,7 @@ export default async function push({
   force = false,
   txParams = {},
   networkFile,
+  contractAlias,
 }: PushParams): Promise<void | never> {
   const controller = new NetworkController(network, txParams, networkFile);
 
@@ -18,8 +19,8 @@ export default async function push({
     if (deployDependencies) await controller.deployDependencies();
     if (deployProxyAdmin) await controller.deployProxyAdmin();
     if (deployProxyFactory) await controller.deployProxyFactory();
-    await controller.push(reupload, force);
-    const { appAddress } = controller;
+    contractAlias ? await controller.pushSingle(contractAlias, force) : await controller.push(reupload, force);
+
     controller.writeNetworkPackageIfNeeded();
   } catch (error) {
     const cb = () => controller.writeNetworkPackageIfNeeded();

--- a/packages/cli/src/scripts/push.ts
+++ b/packages/cli/src/scripts/push.ts
@@ -20,7 +20,7 @@ export default async function push({
     if (deployProxyAdmin) await controller.deployProxyAdmin();
     if (deployProxyFactory) await controller.deployProxyFactory();
     contractAlias ? await controller.pushSingle(contractAlias, force) : await controller.push(reupload, force);
-
+    const { appAddress } = controller;
     controller.writeNetworkPackageIfNeeded();
   } catch (error) {
     const cb = () => controller.writeNetworkPackageIfNeeded();

--- a/packages/lib/contracts/Upgradeable.sol
+++ b/packages/lib/contracts/Upgradeable.sol
@@ -1,0 +1,6 @@
+pragma solidity >=0.4.24 <0.6.0;
+
+import "./Initializable.sol";
+
+contract Upgradeable is Initializable {}
+

--- a/packages/lib/src/artifacts/Contract.ts
+++ b/packages/lib/src/artifacts/Contract.ts
@@ -151,6 +151,7 @@ export function createContract(schema: any): Contract {
   return _wrapContractInstance(schema, contract);
 }
 
+// TODO: move to cli
 export function contractMethodsFromAbi(
   instance: Contract,
   constant: ContractMethodMutability = ContractMethodMutability.NotConstant,

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -12,6 +12,7 @@ import Semver from './utils/Semver';
 import { Loggy } from './utils/Logger';
 import FileSystem from './utils/FileSystem';
 import Contracts from './artifacts/Contracts';
+import ContractAST from './utils/ContractAST';
 import Contract, {
   contractMethodsFromAst,
   contractMethodsFromAbi,
@@ -109,6 +110,7 @@ export {
   AppProject,
   SimpleProject,
   Contract,
+  ContractAST,
   ProxyAdminProject,
   ValidationInfo,
   AppProxyMigrator,

--- a/packages/lib/src/utils/ContractAST.ts
+++ b/packages/lib/src/utils/ContractAST.ts
@@ -201,7 +201,7 @@ export default class ContractAST {
     if (node.nodes) node.nodes.forEach(this._collectNodes.bind(this));
   }
 
-  private _isValidMethodName(name) {
+  private _isValidMethodName(name): boolean {
     return name !== '' && name !== 'isConstructor';
   }
 }


### PR DESCRIPTION
This PR (which is still work in progress) adds the ability to do *regular deploys*, that is to say, to create non upgradeable instances that don't rely in proxies to work.

### TODO:
- ~Rename Initializable to Upgradeable (and keep alias?)~
- Fix and add tests
- Add Regular to "ProxyType" (and rename to InstanceType)
- ~Verify that Upgradeable is not in the inheritance chain, otherwise fail~
- Check that Upgradeable is from openzeppelin/upgrades
- ~Remove initializable function prompt for regular deploys~
- Hide regular instances from upgrade interactive prompt
- ~Rename create to deploy (and keep alias)~
- Review all commands one by one and think about how this change affects each one