### PR TITLE
Fix npm install bug in manual

### DIFF
--- a/packages/docs/modules/ROOT/pages/linking.adoc
+++ b/packages/docs/modules/ROOT/pages/linking.adoc
@@ -92,7 +92,7 @@ In order to support contract upgrades, the OpenZeppelin SDK xref:pattern.adoc#th
 
 [source,console]
 ----
-npm install @openzeppelin/upgrades@2.4.0
+npm install @openzeppelin/upgrades
 ----
 
 Now, let's write our exchange contract in `contracts/TokenExchange.sol`, using an _initializer_ to set its initial state:


### PR DESCRIPTION
The 2.4.0 version of @openzeppelin/upgrades no longer exists. Let's remove the version specification.

```
# npm install @openzeppelin/upgrades@2.4.0
npm ERR! code ETARGET
npm ERR! notarget No matching version found for @openzeppelin/upgrades@2.4.0.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
```