### PR TITLE
Force compilation to fix tests

### DIFF
--- a/packages/cli/scripts/test.sh
+++ b/packages/cli/scripts/test.sh
@@ -32,7 +32,9 @@ fi
 
 if [ "$CI" = true ]; then
   node_modules/.bin/truffle version
-  node_modules/.bin/truffle compile
 fi
+
+rm -rf build/contracts
+node_modules/.bin/truffle compile
 
 TS_NODE_PROJECT="tsconfig.test.json" node_modules/.bin/truffle test --network testing "$@"


### PR DESCRIPTION
Fixes issues reported by @abcoathup in #1241.

I'm not sure why the test script was only compiling in the CI before. I suspect it was because it doesn't work without `rm -rf`-ing the `build/contracts` directory first... And this wasn't necessary in the CI since it's a clean environment.