### PR TITLE
Typechain support

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -157,6 +157,8 @@
     "sinon-chai": "^3.2.0",
     "truffle": "^5.0.5",
     "ts-node": "^7.0.1",
+    "typechain": "^1.0.3",
+    "typechain-target-web3-v1": "^1.0.0",
     "typescript": "^3.2.2",
     "yargs": "^7.1.0"
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -120,6 +120,10 @@
     "solidity-parser-antlr": "^0.4.2",
     "spinnies": "^0.3.0",
     "truffle-config": "1.1.16",
+    "ts-generator": "^0.0.8",
+    "typechain": "^1.0.3",
+    "typechain-target-truffle": "^1.0.0",
+    "typechain-target-web3-v1": "^1.0.0",
     "underscore": "^1.9.1",
     "uuid": "^3.3.3",
     "web3": "1.2.2",
@@ -157,8 +161,6 @@
     "sinon-chai": "^3.2.0",
     "truffle": "^5.0.5",
     "ts-node": "^7.0.1",
-    "typechain": "^1.0.3",
-    "typechain-target-web3-v1": "^1.0.0",
     "typescript": "^3.2.2",
     "yargs": "^7.1.0"
   }

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -1,6 +1,6 @@
 import { compile } from '../models/compiler/Compiler';
 import { CompileParams } from '../scripts/interfaces';
-import { ProjectCompilerOptions } from '../models/compiler/solidity/SolidityProjectCompiler';
+import { ProjectCompilerOptions } from '../models/compiler/ProjectCompilerOptions';
 import Telemetry from '../telemetry';
 
 const name = 'compile';

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -2,6 +2,10 @@ import { compile } from '../models/compiler/Compiler';
 import { CompileParams } from '../scripts/interfaces';
 import { ProjectCompilerOptions } from '../models/compiler/ProjectCompilerOptions';
 import Telemetry from '../telemetry';
+import ProjectFile from '../models/files/ProjectFile';
+import isundefined from 'lodash.isundefined';
+import { promptIfNeeded } from '../prompts/prompt';
+import { TypechainQuestions } from '../prompts/typechain';
 
 const name = 'compile';
 const signature = `${name}`;
@@ -31,7 +35,7 @@ const register: (program: any) => any = program =>
     .action(action);
 
 async function action(options: CompileParams & { interactive: boolean }): Promise<void> {
-  const { evmVersion, solcVersion: version, optimizer, optimizerRuns } = options;
+  const { evmVersion, solcVersion: version, optimizer, optimizerRuns, interactive } = options;
 
   // Handle optimizer option:
   //- on --optimizer or --optimizer=on, enable it
@@ -56,6 +60,17 @@ async function action(options: CompileParams & { interactive: boolean }): Promis
       runs: optimizerRuns && parseInt(optimizerRuns),
     },
   };
+
+  // If typechain settings are undefined, we are running from an old project, so we ask the user if they want to enable it if we find a ts-config (this last bit handled by the typechain questions)
+  const projectFile = new ProjectFile();
+  if (!projectFile.compilerOptions || !projectFile.compilerOptions.typechain || isundefined(projectFile.compilerOptions.typechain.enabled)) {
+    const { typechainEnabled, typechainTarget, typechainOutdir } = await promptIfNeeded({ args: { typechainEnabled: undefined, typechainTarget: undefined, typechainOutdir: undefined }, defaults: {}, props: TypechainQuestions }, interactive);
+    compilerOptions.typechain = { enabled: typechainEnabled };
+    if (typechainEnabled) {
+      Object.assign(compilerOptions.typechain, { outDir: typechainOutdir, target: typechainTarget });
+      compilerOptions.force = true;
+    }
+  }
 
   await Telemetry.report(
     'compile',

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -63,8 +63,19 @@ async function action(options: CompileParams & { interactive: boolean }): Promis
 
   // If typechain settings are undefined, we are running from an old project, so we ask the user if they want to enable it if we find a ts-config (this last bit handled by the typechain questions)
   const projectFile = new ProjectFile();
-  if (!projectFile.compilerOptions || !projectFile.compilerOptions.typechain || isundefined(projectFile.compilerOptions.typechain.enabled)) {
-    const { typechainEnabled, typechainTarget, typechainOutdir } = await promptIfNeeded({ args: { typechainEnabled: undefined, typechainTarget: undefined, typechainOutdir: undefined }, defaults: {}, props: TypechainQuestions }, interactive);
+  if (
+    !projectFile.compilerOptions ||
+    !projectFile.compilerOptions.typechain ||
+    isundefined(projectFile.compilerOptions.typechain.enabled)
+  ) {
+    const { typechainEnabled, typechainTarget, typechainOutdir } = await promptIfNeeded(
+      {
+        args: { typechainEnabled: undefined, typechainTarget: undefined, typechainOutdir: undefined },
+        defaults: {},
+        props: TypechainQuestions,
+      },
+      interactive,
+    );
     compilerOptions.typechain = { enabled: typechainEnabled };
     if (typechainEnabled) {
       Object.assign(compilerOptions.typechain, { outDir: typechainOutdir, target: typechainTarget });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -30,7 +30,13 @@ const register: (program: any) => any = program =>
 async function action(projectName: string, version: string, options: any): Promise<void> {
   const { publish, force, link, install: installDependencies, interactive, typechainOutdir, typechain } = options;
 
-  const args = { name: projectName, version, typechainEnabled: (typechain ? true : typechain), typechainTarget: typechain, typechainOutdir };
+  const args = {
+    name: projectName,
+    version,
+    typechainEnabled: typechain ? true : typechain,
+    typechainTarget: typechain,
+    typechainOutdir,
+  };
   const props = getCommandProps();
   const defaults = FileSystem.parseJsonIfExists('package.json') || { version: '1.0.0' };
   const prompted = await promptIfNeeded({ args, defaults, props }, interactive);
@@ -68,7 +74,7 @@ function getCommandProps(): InquirerQuestions {
         return `Invalid semantic version: ${input}`;
       },
     },
-    ... TypechainQuestions
+    ...TypechainQuestions,
   };
 }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -20,7 +20,7 @@ const register: (program: any) => any = program =>
     .option('--publish', 'automatically publishes your project upon pushing it to a network')
     .option('--force', 'overwrite existing project if there is one')
     .option('--typechain <target>', 'enable typechain support with specified target (web3-v1, ethers, or truffle)')
-    .option('--typechain-outdir <path>', 'output directory for typechain compilation (defaults to types/contracts)')
+    .option('--typechain-outdir <path>', 'set output directory for typechain compilation (defaults to types/contracts)')
     .option('--link <dependency>', 'link to a dependency')
     .option('--no-install', 'skip installing packages dependencies locally')
     .withPushOptions()

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -17,7 +17,7 @@ const register: (program: any) => any = program =>
     .command(signature, undefined, { noHelp: true })
     .usage('<project-name> [version]')
     .description(description)
-    .option('--publish', 'automatically publishes your project upon pushing it to a network')
+    .option('--publish', 'automatically publish your project upon pushing it to a network')
     .option('--force', 'overwrite existing project if there is one')
     .option('--typechain <target>', 'enable typechain support with specified target (web3-v1, ethers, or truffle)')
     .option('--typechain-outdir <path>', 'set output directory for typechain compilation (defaults to types/contracts)')

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -33,7 +33,7 @@ async function action(projectName: string, version: string, options: any): Promi
   const args = {
     name: projectName,
     version,
-    typechainEnabled: typechain ? true : typechain,
+    typechainEnabled: typechain ? true : typechain, // keep undefined and false values separate, since undefined means that the user hasn't chosen, and false means they don't want to use it
     typechainTarget: typechain,
     typechainOutdir,
   };

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -6,6 +6,7 @@ import { FileSystem } from '@openzeppelin/upgrades';
 import ProjectFile from '../models/files/ProjectFile';
 import { notEmpty } from '../prompts/validators';
 import Telemetry from '../telemetry';
+import { TypechainQuestions } from '../prompts/typechain';
 
 const name = 'init';
 const signature = `${name} [project-name] [version]`;
@@ -67,29 +68,7 @@ function getCommandProps(): InquirerQuestions {
         return `Invalid semantic version: ${input}`;
       },
     },
-    typechainEnabled: {
-      message: 'Enable typechain support?',
-      type: 'confirm',
-      default: true,
-      when: () => FileSystem.exists('tsconfig.json')
-    },
-    typechainTarget: {
-      message: 'Typechain compilation target',
-      type: 'list',
-      choices: [
-        { name: 'web3-v1 compatible', value: 'web3-v1' },
-        { name: 'truffle-contract compatible', value: 'truffle' },
-        { name: 'ethers.js compatible', value: 'ethers' }
-      ],
-      when: ({ typechainEnabled }) => typechainEnabled
-    },
-    typechainOutdir: {
-      message: 'Typechain output directory',
-      type: 'input',
-      validate: notEmpty,
-      default: './types/contracts/',
-      when: ({ typechainEnabled }) => typechainEnabled
-    }
+    ... TypechainQuestions
   };
 }
 

--- a/packages/cli/src/models/compiler/Compiler.ts
+++ b/packages/cli/src/models/compiler/Compiler.ts
@@ -1,5 +1,5 @@
 import { execFile as callbackExecFile, ExecException } from 'child_process';
-import { Loggy } from '@openzeppelin/upgrades';
+import { Loggy, Contracts } from '@openzeppelin/upgrades';
 import Truffle from '../config/TruffleConfig';
 import { compileProject, ProjectCompileResult } from './solidity/SolidityProjectCompiler';
 import { ProjectCompilerOptions } from './ProjectCompilerOptions';
@@ -25,6 +25,8 @@ export async function compile(
       enabled: false,
       runs: 200,
     },
+    inputDir: Contracts.getLocalContractsDir(),
+    outputDir: Contracts.getLocalBuildDir(),
   };
   merge(resolvedOptions, projectFile.compilerOptions, compilerOptions);
 

--- a/packages/cli/src/models/compiler/ProjectCompilerOptions.ts
+++ b/packages/cli/src/models/compiler/ProjectCompilerOptions.ts
@@ -2,8 +2,8 @@ import { CompilerOptions } from './solidity/SolidityContractsCompiler';
 
 export interface TypechainOptions {
   enabled: boolean;
-  outDir: string;
-  target: string;
+  outDir?: string;
+  target?: string;
 }
 
 export interface ProjectCompilerOptions extends CompilerOptions {

--- a/packages/cli/src/models/compiler/ProjectCompilerOptions.ts
+++ b/packages/cli/src/models/compiler/ProjectCompilerOptions.ts
@@ -1,0 +1,15 @@
+import { CompilerOptions } from './solidity/SolidityContractsCompiler';
+
+export interface TypechainOptions {
+  enabled: boolean;
+  outDir: string;
+  target: string;
+}
+
+export interface ProjectCompilerOptions extends CompilerOptions {
+  manager?: string;
+  inputDir?: string;
+  outputDir?: string;
+  force?: boolean;
+  typechain?: TypechainOptions;
+}

--- a/packages/cli/src/models/compiler/Typechain.ts
+++ b/packages/cli/src/models/compiler/Typechain.ts
@@ -1,0 +1,37 @@
+import { mkdirpSync } from 'fs-extra';
+import path from 'path';
+
+export default async function typechain(files: string, outDir: string, target: string): Promise<void> {
+  checkModule();
+
+  /* eslint-disable @typescript-eslint/no-var-requires */
+  const { tsGenerator } = require('ts-generator');
+  const { TypeChain: typeChain } = require('typechain/dist/TypeChain');
+  /* eslint-enable @typescript-eslint/no-var-requires */
+
+  const cwd = process.cwd();
+  mkdirpSync(outDir);
+
+  // Hack required until https://github.com/ethereum-ts/TypeChain/pull/186 is merged
+  const relativeOutDir = path.relative(cwd, outDir);
+
+  return tsGenerator(
+    { cwd },
+    new typeChain({
+      cwd,
+      rawConfig: {
+        files,
+        outDir: relativeOutDir,
+        target,
+      },
+    }),
+  );
+}
+
+function checkModule() {
+  try {
+    require.resolve('typechain');
+  } catch {
+    throw new Error("Could not find module 'typechain'. Please install it to support typescript contract wrappers.");
+  }
+}

--- a/packages/cli/src/models/compiler/Typechain.ts
+++ b/packages/cli/src/models/compiler/Typechain.ts
@@ -1,14 +1,9 @@
 import { mkdirpSync } from 'fs-extra';
 import path from 'path';
+import { tsGenerator } from 'ts-generator';
+import { TypeChain as typeChain } from 'typechain/dist/TypeChain';
 
 export default async function typechain(files: string, outDir: string, target: string): Promise<void> {
-  checkModule();
-
-  /* eslint-disable @typescript-eslint/no-var-requires */
-  const { tsGenerator } = require('ts-generator');
-  const { TypeChain: typeChain } = require('typechain/dist/TypeChain');
-  /* eslint-enable @typescript-eslint/no-var-requires */
-
   const cwd = process.cwd();
   mkdirpSync(outDir);
 
@@ -26,12 +21,4 @@ export default async function typechain(files: string, outDir: string, target: s
       },
     }),
   );
-}
-
-function checkModule() {
-  try {
-    require.resolve('typechain');
-  } catch {
-    throw new Error("Could not find module 'typechain'. Please install it to support typescript contract wrappers.");
-  }
 }

--- a/packages/cli/src/models/compiler/solidity/SolidityProjectCompiler.ts
+++ b/packages/cli/src/models/compiler/solidity/SolidityProjectCompiler.ts
@@ -10,7 +10,6 @@ import { Loggy, Contracts } from '@openzeppelin/upgrades';
 import {
   RawContract,
   CompiledContract,
-  CompilerOptions,
   resolveCompilerVersion,
   compileWith,
   DEFAULT_OPTIMIZER,
@@ -21,6 +20,7 @@ import { gatherSources } from './ResolverEngineGatherer';
 import { SolcBuild } from './CompilerProvider';
 import { compilerVersionsMatch, compilerSettingsMatch } from '../../../utils/solidity';
 import { tryFunc } from '../../../utils/try';
+import { ProjectCompilerOptions } from '../ProjectCompilerOptions';
 
 export async function compileProject(options: ProjectCompilerOptions = {}): Promise<ProjectCompileResult> {
   const projectCompiler = new SolidityProjectCompiler({
@@ -33,19 +33,19 @@ export async function compileProject(options: ProjectCompilerOptions = {}): Prom
   return {
     contracts: projectCompiler.contracts,
     compilerVersion: projectCompiler.compilerVersion,
+    artifacts: projectCompiler.compilerOutput,
   };
 }
 
-export interface ProjectCompilerOptions extends CompilerOptions {
-  manager?: string;
-  inputDir?: string;
-  outputDir?: string;
-  force?: boolean;
+export interface CompiledContract {
+  filePath: string;
+  contractName: string;
 }
 
 export interface ProjectCompileResult {
   compilerVersion: SolcBuild;
   contracts: RawContract[];
+  artifacts: CompiledContract[];
 }
 
 class SolidityProjectCompiler {
@@ -191,6 +191,7 @@ class SolidityProjectCompiler {
         const buildFileName = `${this.outputDir}/${name}.json`;
         if (networksInfo[name]) Object.assign(data, { networks: networksInfo[name] });
         await writeJson(buildFileName, data, { spaces: 2 });
+        return { filePath: buildFileName, contractName: name };
       }),
     );
   }

--- a/packages/cli/src/models/files/ProjectFile.ts
+++ b/packages/cli/src/models/files/ProjectFile.ts
@@ -26,7 +26,7 @@ interface ConfigFileCompilerOptions {
     enabled: boolean;
     outDir?: string;
     target?: string;
-  }
+  };
 }
 
 interface ProjectFileData {
@@ -183,7 +183,7 @@ export default class ProjectFile {
         enabled: optimizer && optimizer.enabled,
         runs: optimizer && optimizer.runs && parseInt(optimizer.runs),
       },
-      typechain
+      typechain,
     };
   }
 
@@ -207,7 +207,7 @@ export default class ProjectFile {
           runs: optimizer && optimizer.runs && optimizer.runs.toString(),
         },
       },
-      typechain
+      typechain,
     };
 
     this.data.compiler =

--- a/packages/cli/src/models/files/ProjectFile.ts
+++ b/packages/cli/src/models/files/ProjectFile.ts
@@ -22,6 +22,11 @@ interface ConfigFileCompilerOptions {
       runs?: string;
     };
   };
+  typechain: {
+    enabled: boolean;
+    outDir?: string;
+    target?: string;
+  }
 }
 
 interface ProjectFileData {
@@ -164,6 +169,7 @@ export default class ProjectFile {
     const inputDir = config && config.contractsDir;
     const outputDir = config && config.artifactsDir;
     const compilerSettings = config && config.compilerSettings;
+    const typechain = config && config.typechain;
     const evmVersion = compilerSettings && compilerSettings.evmVersion;
     const optimizer = compilerSettings && compilerSettings.optimizer;
 
@@ -177,6 +183,7 @@ export default class ProjectFile {
         enabled: optimizer && optimizer.enabled,
         runs: optimizer && optimizer.runs && parseInt(optimizer.runs),
       },
+      typechain
     };
   }
 
@@ -187,7 +194,7 @@ export default class ProjectFile {
   }
 
   public setCompilerOptions(options: ProjectCompilerOptions): void {
-    const { manager, version, outputDir, inputDir, evmVersion, optimizer } = options;
+    const { manager, version, outputDir, inputDir, evmVersion, optimizer, typechain } = options;
     const configOptions: ConfigFileCompilerOptions = {
       manager,
       solcVersion: version,
@@ -200,6 +207,7 @@ export default class ProjectFile {
           runs: optimizer && optimizer.runs && optimizer.runs.toString(),
         },
       },
+      typechain
     };
 
     this.data.compiler =

--- a/packages/cli/src/models/files/ProjectFile.ts
+++ b/packages/cli/src/models/files/ProjectFile.ts
@@ -8,7 +8,7 @@ import Dependency from '../dependency/Dependency';
 import { MANIFEST_VERSION, checkVersion } from './ManifestVersion';
 import { OPEN_ZEPPELIN_FOLDER } from './constants';
 import NetworkFile from './NetworkFile';
-import { ProjectCompilerOptions } from '../compiler/solidity/SolidityProjectCompiler';
+import { ProjectCompilerOptions } from '../compiler/ProjectCompilerOptions';
 
 interface ConfigFileCompilerOptions {
   manager: string;

--- a/packages/cli/src/prompts/typechain.ts
+++ b/packages/cli/src/prompts/typechain.ts
@@ -1,0 +1,29 @@
+import { FileSystem } from "@openzeppelin/upgrades";
+import { notEmpty } from "./validators";
+import { InquirerQuestions } from "./prompt";
+
+export const TypechainQuestions : InquirerQuestions = {
+  typechainEnabled: {
+    message: 'Enable typechain support?',
+    type: 'confirm',
+    default: true,
+    when: () => FileSystem.exists('tsconfig.json')
+  },
+  typechainTarget: {
+    message: 'Typechain compilation target',
+    type: 'list',
+    choices: [
+      { name: 'web3-v1 compatible', value: 'web3-v1' },
+      { name: 'truffle-contract compatible', value: 'truffle' },
+      { name: 'ethers.js compatible', value: 'ethers' }
+    ],
+    when: ({ typechainEnabled }) => typechainEnabled
+  },
+  typechainOutdir: {
+    message: 'Typechain output directory',
+    type: 'input',
+    validate: notEmpty,
+    default: './types/contracts/',
+    when: ({ typechainEnabled }) => typechainEnabled
+  }
+};

--- a/packages/cli/src/prompts/typechain.ts
+++ b/packages/cli/src/prompts/typechain.ts
@@ -1,13 +1,13 @@
-import { FileSystem } from "@openzeppelin/upgrades";
-import { notEmpty } from "./validators";
-import { InquirerQuestions } from "./prompt";
+import { FileSystem } from '@openzeppelin/upgrades';
+import { notEmpty } from './validators';
+import { InquirerQuestions } from './prompt';
 
-export const TypechainQuestions : InquirerQuestions = {
+export const TypechainQuestions: InquirerQuestions = {
   typechainEnabled: {
     message: 'Enable typechain support?',
     type: 'confirm',
     default: true,
-    when: () => FileSystem.exists('tsconfig.json')
+    when: () => FileSystem.exists('tsconfig.json'),
   },
   typechainTarget: {
     message: 'Typechain compilation target',
@@ -15,15 +15,15 @@ export const TypechainQuestions : InquirerQuestions = {
     choices: [
       { name: 'web3-v1 compatible', value: 'web3-v1' },
       { name: 'truffle-contract compatible', value: 'truffle' },
-      { name: 'ethers.js compatible', value: 'ethers' }
+      { name: 'ethers.js compatible', value: 'ethers' },
     ],
-    when: ({ typechainEnabled }) => typechainEnabled
+    when: ({ typechainEnabled }) => typechainEnabled,
   },
   typechainOutdir: {
     message: 'Typechain output directory',
     type: 'input',
     validate: notEmpty,
     default: './types/contracts/',
-    when: ({ typechainEnabled }) => typechainEnabled
-  }
+    when: ({ typechainEnabled }) => typechainEnabled,
+  },
 };

--- a/packages/cli/src/scripts/init.ts
+++ b/packages/cli/src/scripts/init.ts
@@ -10,9 +10,17 @@ export default async function init({
   installDependencies = false,
   force = false,
   projectFile = new ProjectFile(),
+  typechainEnabled = false,
+  typechainOutdir = null,
+  typechainTarget = null
 }: InitParams): Promise<void | never> {
   const controller = new LocalController(projectFile, true);
   controller.init(name, version, force, publish);
+
+  const typechain = { enabled: typechainEnabled };
+  if (typechainEnabled) Object.assign(typechain, { outDir: typechainOutdir, target: typechainTarget });
+  controller.projectFile.setCompilerOptions({ typechain });
+  
   if (dependencies.length !== 0) await controller.linkDependencies(dependencies, installDependencies);
   controller.writePackage();
 }

--- a/packages/cli/src/scripts/init.ts
+++ b/packages/cli/src/scripts/init.ts
@@ -12,7 +12,7 @@ export default async function init({
   projectFile = new ProjectFile(),
   typechainEnabled = false,
   typechainOutdir = null,
-  typechainTarget = null
+  typechainTarget = null,
 }: InitParams): Promise<void | never> {
   const controller = new LocalController(projectFile, true);
   controller.init(name, version, force, publish);
@@ -20,7 +20,7 @@ export default async function init({
   const typechain = { enabled: typechainEnabled };
   if (typechainEnabled) Object.assign(typechain, { outDir: typechainOutdir, target: typechainTarget });
   controller.projectFile.setCompilerOptions({ typechain });
-  
+
   if (dependencies.length !== 0) await controller.linkDependencies(dependencies, installDependencies);
   controller.writePackage();
 }

--- a/packages/cli/src/scripts/interfaces.ts
+++ b/packages/cli/src/scripts/interfaces.ts
@@ -97,6 +97,9 @@ export interface InitParams extends Dependencies {
   force?: boolean;
   publish?: boolean;
   projectFile?: ProjectFile;
+  typechainEnabled?: boolean;
+  typechainTarget?: string;
+  typechainOutdir?: string;
 }
 
 export interface UnpackParams {

--- a/packages/cli/test/commands/compile.test.js
+++ b/packages/cli/test/commands/compile.test.js
@@ -6,14 +6,14 @@ import { stubCommands, itShouldParse } from './share';
 describe('compile command', function() {
   stubCommands();
 
-  itShouldParse('should call compile', 'compiler', 'zos compile', function(compiler) {
+  itShouldParse('should call compile', 'compiler', 'zos compile --no-interactive', function(compiler) {
     compiler.should.have.been.calledOnce;
   });
 
   itShouldParse(
     'should call compile with options',
     'compiler',
-    'zos compile --solc-version 0.5.0 --optimizer --optimizer-runs 300 --evm-version petersburg',
+    'zos compile --solc-version 0.5.0 --optimizer --optimizer-runs 300 --evm-version petersburg --no-interactive',
     function(compiler) {
       compiler.should.have.been.calledWithMatch({
         manager: 'openzeppelin',
@@ -27,7 +27,7 @@ describe('compile command', function() {
   itShouldParse(
     'should call compile with optimizer disabled',
     'compiler',
-    'zos compile --solc-version 0.5.0 --optimizer=off',
+    'zos compile --solc-version 0.5.0 --optimizer=off --no-interactive',
     function(compiler) {
       compiler.should.have.been.calledWithMatch({
         manager: 'openzeppelin',

--- a/packages/cli/test/commands/init.test.js
+++ b/packages/cli/test/commands/init.test.js
@@ -9,7 +9,7 @@ describe('init command', function() {
   itShouldParse(
     'should call init script with name, version and dependencies',
     'init',
-    'zos init MyApp 0.2.0 --force --no-install --link mock-stdlib@1.1.0,mock-stdlib-2@1.2.0',
+    'zos init MyApp 0.2.0 --force --no-install --link mock-stdlib@1.1.0,mock-stdlib-2@1.2.0 --no-interactive',
     function(init) {
       const dependencies = ['mock-stdlib@1.1.0', 'mock-stdlib-2@1.2.0'];
       init.should.have.been.calledWithExactly({
@@ -19,6 +19,9 @@ describe('init command', function() {
         installDependencies: false,
         force: true,
         publish: undefined,
+        typechainEnabled: undefined,
+        typechainOutdir: undefined,
+        typechainTarget: undefined,
       });
     },
   );
@@ -26,7 +29,7 @@ describe('init command', function() {
   itShouldParse(
     'should call push script when passing --push option',
     'push',
-    'zos init MyApp 0.2.0 --push test',
+    'zos init MyApp 0.2.0 --push test --no-interactive',
     function(push) {
       push.should.have.been.calledWithExactly({
         deployProxyAdmin: undefined,
@@ -40,14 +43,41 @@ describe('init command', function() {
     },
   );
 
-  itShouldParse('should call init script with light flag', 'init', 'zos init MyApp 0.2.0 --publish', function(init) {
-    init.should.have.been.calledWithExactly({
-      name: 'MyApp',
-      version: '0.2.0',
-      publish: true,
-      force: undefined,
-      installDependencies: undefined,
-      dependencies: [],
-    });
-  });
+  itShouldParse(
+    'should call init script with light flag',
+    'init',
+    'zos init MyApp 0.2.0 --publish --no-interactive',
+    function(init) {
+      init.should.have.been.calledWithExactly({
+        name: 'MyApp',
+        version: '0.2.0',
+        publish: true,
+        force: undefined,
+        installDependencies: undefined,
+        dependencies: [],
+        typechainEnabled: undefined,
+        typechainOutdir: undefined,
+        typechainTarget: undefined,
+      });
+    },
+  );
+
+  itShouldParse(
+    'should call init script with typechain',
+    'init',
+    'zos init MyApp 0.2.0 --typechain=web3-v1 --typechain-outdir=foo/bar --no-interactive',
+    function(init) {
+      init.should.have.been.calledWithExactly({
+        name: 'MyApp',
+        version: '0.2.0',
+        publish: undefined,
+        force: undefined,
+        installDependencies: undefined,
+        dependencies: [],
+        typechainEnabled: true,
+        typechainOutdir: 'foo/bar',
+        typechainTarget: 'web3-v1',
+      });
+    },
+  );
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1339,6 +1339,13 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
+"@types/mkdirp@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.5.2.tgz#503aacfe5cc2703d5484326b1b27efa67a339c1f"
+  integrity sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/mocha@^5.2.5":
   version "5.2.7"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.7.tgz#315d570ccb56c53452ff8638738df60726d5b6ea"
@@ -1373,6 +1380,18 @@
   version "2.0.31"
   resolved "https://registry.yarnpkg.com/@types/npm/-/npm-2.0.31.tgz#aad3aef7e165f2911a052abf548fbcc1bb468577"
   integrity sha512-v4JpUx83wVGItleYsnYeZrM8NTLSnYDfTE/iGm4owy6zZPNFNmnsvvrxiYtG3cVHt/XutzTjUBQ9Bh8bnvEkCw==
+  dependencies:
+    "@types/node" "*"
+
+"@types/prettier@^1.13.2":
+  version "1.18.3"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.18.3.tgz#64ff53329ce16139f17c3db9d3e0487199972cd8"
+  integrity sha512-48rnerQdcZ26odp+HOvDGX8IcUkYOCuMc2BodWYTe956MqkHlOGAG4oFQ83cjZ0a4GAgj7mb4GUClxYd2Hlodg==
+
+"@types/resolve@^0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
+  integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
   dependencies:
     "@types/node" "*"
 
@@ -1699,6 +1718,20 @@ arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
+
+array-back@^1.0.3, array-back@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-1.0.4.tgz#644ba7f095f7ffcf7c43b5f0dc39d3c1f03c063b"
+  integrity sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=
+  dependencies:
+    typical "^2.6.0"
+
+array-back@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-2.0.0.tgz#6877471d51ecc9c9bfa6136fb6c7d5fe69748022"
+  integrity sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==
+  dependencies:
+    typical "^2.6.1"
 
 array-differ@^2.0.3:
   version "2.1.0"
@@ -3555,6 +3588,15 @@ command-exists@^1.2.8:
   resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.8.tgz#715acefdd1223b9c9b37110a149c6392c2852291"
   integrity sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==
 
+command-line-args@^4.0.7:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-4.0.7.tgz#f8d1916ecb90e9e121eda6428e41300bfb64cc46"
+  integrity sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==
+  dependencies:
+    array-back "^2.0.0"
+    find-replace "^1.0.3"
+    typical "^2.6.1"
+
 commander@2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
@@ -4044,7 +4086,7 @@ debug@3.1.0, debug@=3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@3.2.6, debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.6:
+debug@3.2.6, debug@^3.0.0, debug@^3.0.1, debug@^3.1.0, debug@^3.1.1, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -5586,6 +5628,14 @@ finalhandler@~1.1.2:
     parseurl "~1.3.3"
     statuses "~1.5.0"
     unpipe "~1.0.0"
+
+find-replace@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/find-replace/-/find-replace-1.0.3.tgz#b88e7364d2d9c959559f388c66670d6130441fa0"
+  integrity sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=
+  dependencies:
+    array-back "^1.0.4"
+    test-value "^2.1.0"
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -8791,7 +8841,7 @@ mock-fs@^4.1.0:
 "mock-stdlib-invalid@file:./packages/cli/test/mocks/mock-stdlib-invalid":
   version "1.1.0"
 
-"mock-stdlib-root@file:./packages/cli/test/mocks/mock-stdlib":
+"mock-stdlib-root@file:./packages/cli/test/mocks/mock-stdlib", "mock-stdlib@file:./packages/cli/test/mocks/mock-stdlib":
   version "1.1.0"
 
 "mock-stdlib-undeployed-2@file:./packages/cli/test/mocks/mock-stdlib-undeployed-2":
@@ -8804,9 +8854,6 @@ mock-fs@^4.1.0:
   version "1.1.0"
 
 "mock-stdlib-unsupported@file:./packages/cli/test/mocks/mock-stdlib-unsupported":
-  version "1.1.0"
-
-"mock-stdlib@file:./packages/cli/test/mocks/mock-stdlib":
   version "1.1.0"
 
 "mock-stdlib@file:tests/cli/dependencies/mock-stdlib-1.1.0":
@@ -9947,6 +9994,11 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
+prettier@^1.14.2:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
 prettier@^1.17.1, prettier@^1.18.2:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
@@ -10688,7 +10740,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.4.0:
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.4.0, resolve@^1.8.1:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
@@ -11824,6 +11876,14 @@ term-size@^1.2.0:
   dependencies:
     execa "^0.7.0"
 
+test-value@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/test-value/-/test-value-2.1.0.tgz#11da6ff670f3471a73b625ca4f3fdcf7bb748291"
+  integrity sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=
+  dependencies:
+    array-back "^1.0.3"
+    typical "^2.6.0"
+
 text-extensions@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-2.0.0.tgz#43eabd1b495482fae4a2bf65e5f56c29f69220f6"
@@ -12107,6 +12167,26 @@ truffle@^5.0.5:
     mocha "5.2.0"
     original-require "1.0.1"
 
+ts-essentials@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-1.0.4.tgz#ce3b5dade5f5d97cf69889c11bf7d2da8555b15a"
+  integrity sha512-q3N1xS4vZpRouhYHDPwO0bDW3EZ6SK9CrrDHxi/D6BPReSjpVgWIOpLS2o0gSBZm+7q/wyKp6RVM1AeeW7uyfQ==
+
+ts-generator@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/ts-generator/-/ts-generator-0.0.8.tgz#7bd48ca064db026d9520bcb682b69efc20971d6a"
+  integrity sha512-Gi+aZCELpVL7Mqb+GuMgM+n8JZ/arZZib1iD/R9Ok8JDjOCOCrqS9b1lr72ku7J45WeDCFZxyJoRsiQvhokCnw==
+  dependencies:
+    "@types/mkdirp" "^0.5.2"
+    "@types/prettier" "^1.13.2"
+    "@types/resolve" "^0.0.8"
+    chalk "^2.4.1"
+    glob "^7.1.2"
+    mkdirp "^0.5.1"
+    prettier "^1.14.2"
+    resolve "^1.8.1"
+    ts-essentials "^1.0.0"
+
 ts-node@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-7.0.1.tgz#9562dc2d1e6d248d24bc55f773e3f614337d9baf"
@@ -12195,6 +12275,25 @@ type@^1.0.1:
   resolved "https://registry.yarnpkg.com/type/-/type-1.2.0.tgz#848dd7698dafa3e54a6c479e759c4bc3f18847a0"
   integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
 
+typechain-target-web3-v1@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/typechain-target-web3-v1/-/typechain-target-web3-v1-1.0.0.tgz#45dc6a8cbf2bd0889d42ef3139c386b01cc8f687"
+  integrity sha512-dtFb+LdBxv8kX0QIoRVLrfjkBWXrNm8k9zdrs2tC9L+h67lplw86T/NCz9OFjMIJW9JfV/68rcGuXPPqN/ahcw==
+  dependencies:
+    lodash "^4.17.15"
+
+typechain@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/typechain/-/typechain-1.0.3.tgz#c4465cdc27526989c735774ad96fadbb908bfe01"
+  integrity sha512-GG/isuyXy0vtm4fwfboMqnApU3hUF+XdrpQMMVUIhlHgm1kXxxf+w8+v8shn4gfhRoiATCZGDOt9fbE+/hMhjQ==
+  dependencies:
+    command-line-args "^4.0.7"
+    debug "^3.0.1"
+    fs-extra "^7.0.0"
+    js-sha3 "^0.8.0"
+    lodash "^4.17.15"
+    ts-generator "^0.0.8"
+
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
@@ -12228,6 +12327,11 @@ typewiselite@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/typewiselite/-/typewiselite-1.0.0.tgz#c8882fa1bb1092c06005a97f34ef5c8508e3664e"
   integrity sha1-yIgvobsQksBgBal/NO9chQjjZk4=
+
+typical@^2.6.0, typical@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-2.6.1.tgz#5c080e5d661cbbe38259d2e70a3c7253e873881d"
+  integrity sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=
 
 uglify-js@^3.1.4:
   version "3.6.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12275,6 +12275,13 @@ type@^1.0.1:
   resolved "https://registry.yarnpkg.com/type/-/type-1.2.0.tgz#848dd7698dafa3e54a6c479e759c4bc3f18847a0"
   integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
 
+typechain-target-truffle@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/typechain-target-truffle/-/typechain-target-truffle-1.0.0.tgz#57e6cd2ea582d94b4b4a2a4626b3b21e42662a82"
+  integrity sha512-oacoGf9sBd29GDbf1DC2cE2V1JYvmhYz541zhwYBlbLH9i4mSzlQChDxYibFaifVEKPdZ4eJ+zz23lZ/DsNyYw==
+  dependencies:
+    lodash "^4.17.15"
+
 typechain-target-web3-v1@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/typechain-target-web3-v1/-/typechain-target-web3-v1-1.0.0.tgz#45dc6a8cbf2bd0889d42ef3139c386b01cc8f687"


### PR DESCRIPTION
I added an optional typechain step to the compilation. If this feature is enabled, after compiling, every modified contract is run through typechain to generate typescript wrappers.

The user is queried whether to enable it on two commands, and _only if there is a `tsconfig.json`_ present (I'd like your thoughts on these!)
- Running `oz init`
- Running `oz compile` if there is no typechain info on the project.json file

The user is asked three questions:
- Whether to enable typechain
- Which target to use (web3, ethers, or truffle)
- The output dir

Typechain generation is quite fast, and the packages are rather small. I had initially loaded them lazily, but it ended up not making much of a difference including them in the package (not ethers though, since we don't officially support it).

![typechain-oz-sdk](https://user-images.githubusercontent.com/429604/68979936-cefbd980-07dd-11ea-9946-05f016c97b1e.gif)

Suggest reviewing commit-by-commit.