### PR TITLE
Update gsn-dapp.adoc for Contracts 2.4

### DIFF
--- a/packages/docs/modules/ROOT/pages/gsn-dapp.adoc
+++ b/packages/docs/modules/ROOT/pages/gsn-dapp.adoc
@@ -87,6 +87,12 @@ contract Counter is GSNRecipient {
   ) external view returns (uint256, bytes memory) {
     return _approveRelayedCall();
   }
+
+  function _preRelayedCall(bytes memory context) internal returns (bytes32) {
+  }
+
+  function _postRelayedCall(bytes memory context, bool, uint256 actualCharge, bytes32) internal {
+  }
 }
 ----
 


### PR DESCRIPTION
`GSNRecipient` doesn't implement `_preRelayedCall` and `_postRelayedCall` so our `Counter` contract needs to otherwise it is abstract and can't be `oz create`d.

Add empty implementations of `_preRelayedCall` and `_postRelayedCall`