### PR TITLE
Use solidity fuzzy import parser

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,6 +56,7 @@
   },
   "homepage": "https://github.com/OpenZeppelin/openzeppelin-sdk/tree/master/packages/cli#readme",
   "dependencies": {
+    "@openzeppelin/fuzzy-solidity-import-parser": "^0.1.0",
     "@openzeppelin/resolver-engine-core": "^0.3.3",
     "@openzeppelin/resolver-engine-imports-fs": "^0.3.3",
     "@openzeppelin/test-environment": "^0.1.0",
@@ -119,7 +120,6 @@
     "semver": "^5.5.0",
     "simple-git": "^1.110.0",
     "solc-wrapper": "^0.5.8",
-    "solidity-parser-antlr": "^0.4.2",
     "spinnies": "^0.3.0",
     "toposort": "^2.0.2",
     "truffle-config": "1.1.16",

--- a/packages/cli/src/models/compiler/solidity/ResolverEngineGatherer.ts
+++ b/packages/cli/src/models/compiler/solidity/ResolverEngineGatherer.ts
@@ -196,25 +196,3 @@ async function resolveImportFile(
     throw err;
   }
 }
-
-/**
- * This function gathers sources and **REWRITES IMPORTS** inside the source files into resolved, absolute paths instead of using shortcut forms
- * Because the remapping api in solc is not compatible with multiple existing projects and frameworks, changing relative paths to absolute paths
- * makes us avoid any need for finding imports after starting the solc compilation
- * @param roots
- * @param workingDir What's the starting working dir for resolving relative imports in roots
- * @param resolver
- */
-export async function gatherSourcesAndCanonizeImports(
-  roots: string[],
-  workingDir: string,
-  resolver: ResolverEngine<ImportFile>,
-): Promise<ImportFile[]> {
-  function canonizeFile(file: ImportTreeNode) {
-    file.imports.forEach(i => (file.source = file.source.replace(i.uri, i.url)));
-  }
-
-  const sources = await gatherDependencyTree(roots, workingDir, resolver);
-  sources.forEach(canonizeFile);
-  return stripNodes(sources);
-}

--- a/packages/cli/src/models/compiler/solidity/SolidityProjectCompiler.ts
+++ b/packages/cli/src/models/compiler/solidity/SolidityProjectCompiler.ts
@@ -159,7 +159,7 @@ class SolidityProjectCompiler {
     return (
       !maxArtifactsMtimes ||
       !maxSourcesMtimes ||
-      maxArtifactsMtimes < maxSourcesMtimes ||
+      maxArtifactsMtimes <= maxSourcesMtimes ||
       !artifactCompiledVersion ||
       !compilerVersionsMatch(artifactCompiledVersion, this.compilerVersion.longVersion) ||
       !compilerSettingsMatch(currentSettings, artifactSettings)

--- a/packages/cli/src/utils/solidity.ts
+++ b/packages/cli/src/utils/solidity.ts
@@ -1,5 +1,6 @@
 import { eq as semverEq, parse as parseSemver } from 'semver';
 import { CompilerVersionOptions } from '../models/compiler/solidity/SolidityContractsCompiler';
+import { getMetadata } from '@openzeppelin/fuzzy-solidity-import-parser';
 
 export function getPragma(source: string): string {
   if (!source) return null;
@@ -35,15 +36,5 @@ export function compilerSettingsMatch(s1: CompilerVersionOptions, s2: CompilerVe
 }
 
 export function getImports(source: string): string[] {
-  // Copied from https://github.com/nomiclabs/buidler/blob/1cd52f91d7f8b6756c5ac33b78f93b151b072ea4/packages/buidler-core/src/internal/solidity/imports.ts
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const parser = require('solidity-parser-antlr');
-  const ast = parser.parse(source, { tolerant: true });
-
-  const importedFiles: string[] = [];
-  parser.visit(ast, {
-    ImportDirective: (node: { path: string }) => importedFiles.push(node.path),
-  });
-
-  return importedFiles;
+  return getMetadata(source).imports;
 }

--- a/packages/cli/src/utils/solidity.ts
+++ b/packages/cli/src/utils/solidity.ts
@@ -1,7 +1,6 @@
 import { eq as semverEq, parse as parseSemver } from 'semver';
 import { CompilerVersionOptions } from '../models/compiler/solidity/SolidityContractsCompiler';
 import { getMetadata } from '@openzeppelin/fuzzy-solidity-import-parser';
-import { Loggy } from '@openzeppelin/upgrades';
 
 export function getPragma(source: string): string {
   if (!source) return null;
@@ -36,21 +35,6 @@ export function compilerSettingsMatch(s1: CompilerVersionOptions, s2: CompilerVe
   );
 }
 
-export function getImports(source: string, url: string): string[] {
-  try {
-    return getMetadata(source).imports;
-  } catch {
-    // The are two reasons why the parser may crash:
-    //  - the source is not valid Solidity code
-    //  - the parser has a bug
-    // Invalid source will be better diagnosed by the compiler, meaning we shouldn't halt execution so that it gets a
-    // chance to inspect the source. A buggy parser will produce false negatives, but since we're not able to detect
-    // that here, it makes more sense to fail loudly, hopefully leading to a bug report by a user.
-    Loggy.noSpin.warn(__filename, 'getImports', 'solidity-parser-warnings', `Error while parsing ${trimURL(url)}`);
-    return [];
-  }
-}
-
-function trimURL(url: string): string {
-  return url.length < 40 ? url : url.substring(0, 40) + '...';
+export function getImports(source: string): string[] {
+  return getMetadata(source).imports;
 }

--- a/packages/cli/src/utils/solidity.ts
+++ b/packages/cli/src/utils/solidity.ts
@@ -1,6 +1,7 @@
 import { eq as semverEq, parse as parseSemver } from 'semver';
 import { CompilerVersionOptions } from '../models/compiler/solidity/SolidityContractsCompiler';
 import { getMetadata } from '@openzeppelin/fuzzy-solidity-import-parser';
+import { Loggy } from '@openzeppelin/upgrades';
 
 export function getPragma(source: string): string {
   if (!source) return null;
@@ -35,10 +36,21 @@ export function compilerSettingsMatch(s1: CompilerVersionOptions, s2: CompilerVe
   );
 }
 
-export function getImports(source: string): string[] {
+export function getImports(source: string, url: string): string[] {
   try {
     return getMetadata(source).imports;
   } catch {
+    // The are two reasons why the parser may crash:
+    //  - the source is not valid Solidity code
+    //  - the parser has a bug
+    // Invalid source will be better diagnosed by the compiler, meaning we shouldn't halt execution so that it gets a
+    // chance to inspect the source. A buggy parser will produce false negatives, but since we're not able to detect
+    // that here, it makes more sense to fail loudly, hopefully leading to a bug report by a user.
+    Loggy.noSpin.warn(__filename, 'getImports', 'solidity-parser-warnings', `Error while parsing ${trimURL(url)}`);
     return [];
   }
+}
+
+function trimURL(url: string): string {
+  return url.length < 40 ? url : url.substring(0, 40) + '...';
 }

--- a/packages/cli/src/utils/solidity.ts
+++ b/packages/cli/src/utils/solidity.ts
@@ -36,5 +36,9 @@ export function compilerSettingsMatch(s1: CompilerVersionOptions, s2: CompilerVe
 }
 
 export function getImports(source: string): string[] {
-  return getMetadata(source).imports;
+  try {
+    return getMetadata(source).imports;
+  } catch {
+    return [];
+  }
 }

--- a/packages/lib/src/utils/Solidity.ts
+++ b/packages/lib/src/utils/Solidity.ts
@@ -1,5 +1,3 @@
-import flatten from 'truffle-flattener';
-
 export function flattenSourceCode(contractPaths: string[], root = process.cwd()): Promise<any> {
-  return flatten(contractPaths, root);
+  return require('truffle-flattener')(contractPaths, root);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -986,6 +986,15 @@
   dependencies:
     "@types/node" "^12.11.1"
 
+"@openzeppelin/contract-loader@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contract-loader/-/contract-loader-0.4.0.tgz#c28c05d09df94c634d968ed175b5777dfc675872"
+  integrity sha512-K+Pl4tn0FbxMSP0H9sgi61ayCbecpqhQmuBshelC7A3q2MlpcqWRJan0xijpwdtv6TORNd5oZNe/+f3l+GD6tw==
+  dependencies:
+    find-up "^4.1.0"
+    fs-extra "^8.1.0"
+    try-require "^1.2.1"
+
 "@openzeppelin/contract-loader@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contract-loader/-/contract-loader-0.5.0.tgz#f82aeb3a2cecf3f16d97ba2989b2541ca6d045bd"
@@ -1215,37 +1224,6 @@
 "@truffle/error@^0.0.6":
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/@truffle/error/-/error-0.0.6.tgz#75d499845b4b3a40537889e7d04c663afcaee85d"
-
-"@truffle/error@^0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@truffle/error/-/error-0.0.8.tgz#dc94ca36393403449d4b7461bf9452c241e53ec1"
-  integrity sha512-x55rtRuNfRO1azmZ30iR0pf0OJ6flQqbax1hJz+Avk1K5fdmOv5cr22s9qFnwTWnS6Bw0jvJEoR0ITsM7cPKtQ==
-
-"@truffle/interface-adapter@^0.3.3":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@truffle/interface-adapter/-/interface-adapter-0.3.3.tgz#61305378cf81776769ef36c60d394e568ac4a2ee"
-  integrity sha512-l3I4WFTfnBSIfG96IOBRtAIE6AHDAxcOUJE7W5zh9hocQwzQlGWc2yEyyTcLa0656TTM8RxaZZ2S/KdHHMvCaw==
-  dependencies:
-    bn.js "^4.11.8"
-    ethers "^4.0.32"
-    lodash "^4.17.13"
-    web3 "1.2.2"
-
-"@truffle/provider@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@truffle/provider/-/provider-0.2.2.tgz#768ad9f2e64a655277a0dbec03aeb9c1062906e3"
-  integrity sha512-0lN23hJzM6cb1IK4ZjRPHDEdwtcpRwhsfBLLOAzlOFlnFvCHlQWnb7K71mCE9LXrKqjQRDF1vjUpeiKccwoN8Q==
-  dependencies:
-    "@truffle/error" "^0.0.8"
-    "@truffle/interface-adapter" "^0.3.3"
-    web3 "1.2.2"
-
-"@types/bignumber.js@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@types/bignumber.js/-/bignumber.js-5.0.0.tgz#d9f1a378509f3010a3255e9cc822ad0eeb4ab969"
-  integrity sha512-0DH7aPGCClywOFaxxjE6UwpN2kQYe9LwuDQMv+zYA97j5GkOMo8e66LYT+a8JYU7jfmUFRZLa9KycxHDsKXJCA==
-  dependencies:
-    bignumber.js "*"
 
 "@truffle/error@^0.0.8":
   version "0.0.8"
@@ -3046,11 +3024,6 @@ chai-bn@^0.2.0:
   resolved "https://registry.yarnpkg.com/chai-bn/-/chai-bn-0.2.0.tgz#7da60617531e5a8bdf9fbd5d848e693b7405a5cb"
   integrity sha512-h+XqIFikre13N3uiZSc50PZ0VztVjuD/Gytle07EUFkbd8z31tWp37DLAsR1dPozmOLA3yu4hi3IFjJDQ5CKBg==
 
-chai-bn@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/chai-bn/-/chai-bn-0.2.0.tgz#7da60617531e5a8bdf9fbd5d848e693b7405a5cb"
-  integrity sha512-h+XqIFikre13N3uiZSc50PZ0VztVjuD/Gytle07EUFkbd8z31tWp37DLAsR1dPozmOLA3yu4hi3IFjJDQ5CKBg==
-
 chai-string@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/chai-string/-/chai-string-1.5.0.tgz#0bdb2d8a5f1dbe90bc78ec493c1c1c180dd4d3d2"
@@ -3695,11 +3668,6 @@ crypto-browserify@3.12.0:
 crypto-js@^3.1.4:
   version "3.1.8"
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.8.tgz#715f070bf6014f2ae992a98b3929258b713f08d5"
-
-crypto-js@^3.1.9-1:
-  version "3.1.9-1"
-  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.9-1.tgz#fda19e761fc077e01ffbfdc6e9fdfc59e8806cd8"
-  integrity sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=
 
 crypto-js@^3.1.9-1:
   version "3.1.9-1"
@@ -4549,18 +4517,6 @@ ethereum-common@0.2.0:
 ethereum-common@^0.0.18:
   version "0.0.18"
   resolved "https://registry.yarnpkg.com/ethereum-common/-/ethereum-common-0.0.18.tgz#2fdc3576f232903358976eb39da783213ff9523f"
-
-ethereum-ens@^0.7.7:
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/ethereum-ens/-/ethereum-ens-0.7.8.tgz#102874541801507774fef21c9a626fabb1ed0630"
-  integrity sha512-HJBDmF5/abP/IIM6N7rGHmmlQ4yCKIVK4kzT/Mu05+eZn0i5ZlR25LTAE47SVZ7oyTBvOkNJhxhSkWRvjh7srg==
-  dependencies:
-    bluebird "^3.4.7"
-    eth-ens-namehash "^2.0.0"
-    js-sha3 "^0.5.7"
-    pako "^1.0.4"
-    underscore "^1.8.3"
-    web3 "^1.0.0-beta.34"
 
 ethereum-ens@^0.7.7:
   version "0.7.8"
@@ -5673,18 +5629,6 @@ glob-watcher@^5.0.3:
 glob@7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@7.1.3:
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
-  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -8701,13 +8645,6 @@ p-timeout@^3.1.0:
   dependencies:
     p-finally "^1.0.0"
 
-p-timeout@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
-  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
-  dependencies:
-    p-finally "^1.0.0"
-
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
@@ -10544,13 +10481,6 @@ supports-color@6.0.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.0.0.tgz#76cfe742cf1f41bb9b1c29ad03068c05b4c0e40a"
-  integrity sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==
-  dependencies:
-    has-flag "^3.0.0"
-
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -11426,16 +11356,6 @@ web3-bzz@1.2.4:
     swarm-js "0.1.39"
     underscore "1.9.1"
 
-web3-bzz@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/web3-bzz/-/web3-bzz-1.2.4.tgz#a4adb7a8cba3d260de649bdb1f14ed359bfb3821"
-  integrity sha512-MqhAo/+0iQSMBtt3/QI1rU83uvF08sYq8r25+OUZ+4VtihnYsmkkca+rdU0QbRyrXY2/yGIpI46PFdh0khD53A==
-  dependencies:
-    "@types/node" "^10.12.18"
-    got "9.6.0"
-    swarm-js "0.1.39"
-    underscore "1.9.1"
-
 web3-core-helpers@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/web3-core-helpers/-/web3-core-helpers-1.2.1.tgz#f5f32d71c60a4a3bd14786118e633ce7ca6d5d0d"
@@ -11502,14 +11422,6 @@ web3-core-promievent@1.2.1:
 web3-core-promievent@1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/web3-core-promievent/-/web3-core-promievent-1.2.2.tgz#3b60e3f2a0c96db8a891c927899d29d39e66ab1c"
-  dependencies:
-    any-promise "1.3.0"
-    eventemitter3 "3.1.2"
-
-web3-core-promievent@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/web3-core-promievent/-/web3-core-promievent-1.2.4.tgz#75e5c0f2940028722cdd21ba503ebd65272df6cb"
-  integrity sha512-gEUlm27DewUsfUgC3T8AxkKi8Ecx+e+ZCaunB7X4Qk3i9F4C+5PSMGguolrShZ7Zb6717k79Y86f3A00O0VAZw==
   dependencies:
     any-promise "1.3.0"
     eventemitter3 "3.1.2"
@@ -12044,20 +11956,6 @@ web3-utils@1.2.1:
 web3-utils@1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.2.2.tgz#b53a08c40d2c3f31d3c4a28e7d749405df99c8c0"
-  dependencies:
-    bn.js "4.11.8"
-    eth-lib "0.2.7"
-    ethereum-bloom-filters "^1.0.6"
-    ethjs-unit "0.1.6"
-    number-to-bn "1.7.0"
-    randombytes "^2.1.0"
-    underscore "1.9.1"
-    utf8 "3.0.0"
-
-web3-utils@1.2.4, web3-utils@^1.2.1:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.2.4.tgz#96832a39a66b05bf8862a5b0bdad2799d709d951"
-  integrity sha512-+S86Ip+jqfIPQWvw2N/xBQq5JNqCO0dyvukGdJm8fEWHZbckT4WxSpHbx+9KLEWY4H4x9pUwnoRkK87pYyHfgQ==
   dependencies:
     bn.js "4.11.8"
     eth-lib "0.2.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -986,15 +986,6 @@
   dependencies:
     "@types/node" "^12.11.1"
 
-"@openzeppelin/contract-loader@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contract-loader/-/contract-loader-0.4.0.tgz#c28c05d09df94c634d968ed175b5777dfc675872"
-  integrity sha512-K+Pl4tn0FbxMSP0H9sgi61ayCbecpqhQmuBshelC7A3q2MlpcqWRJan0xijpwdtv6TORNd5oZNe/+f3l+GD6tw==
-  dependencies:
-    find-up "^4.1.0"
-    fs-extra "^8.1.0"
-    try-require "^1.2.1"
-
 "@openzeppelin/contract-loader@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contract-loader/-/contract-loader-0.5.0.tgz#f82aeb3a2cecf3f16d97ba2989b2541ca6d045bd"
@@ -1003,6 +994,11 @@
     find-up "^4.1.0"
     fs-extra "^8.1.0"
     try-require "^1.2.1"
+
+"@openzeppelin/fuzzy-solidity-import-parser@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/fuzzy-solidity-import-parser/-/fuzzy-solidity-import-parser-0.1.0.tgz#e137c091aa9ed7753f92b3f5f9d9338929e674ba"
+  integrity sha512-Vavzh+fLY80IVnWs7a4Oj9GO0Oem2I/rs0rIUILNPusMqKB4dxJ1IzD11YSkltjyEuDhm1DHWsRyXYZt9E1w4Q==
 
 "@openzeppelin/resolver-engine-core@^0.3.3":
   version "0.3.3"
@@ -10198,7 +10194,7 @@ solidity-docgen@^0.3.5:
     semver "^6.3.0"
     solc "^0.5.12"
 
-solidity-parser-antlr@^0.4.11, solidity-parser-antlr@^0.4.2:
+solidity-parser-antlr@^0.4.11:
   version "0.4.11"
   resolved "https://registry.yarnpkg.com/solidity-parser-antlr/-/solidity-parser-antlr-0.4.11.tgz#af43e1f13b3b88309a875455f5d6e565b05ee5f1"
 


### PR DESCRIPTION
Increases performance of nothing-to-compile runs by using a custom fuzzy parser that only extracts imports from the text, instead of the full antlr4 parser.

Running both versions in the contracts repository, this yields a 40% speed increase when having nothing to compile.

This commit also lazy-loads truffle-flattener, which was causing significant delays to the CLI startup.