### PR TITLE
Documentation: Update linking.adoc

### DIFF
--- a/packages/docs/modules/ROOT/pages/linking.adoc
+++ b/packages/docs/modules/ROOT/pages/linking.adoc
@@ -92,7 +92,7 @@ In order to support contract upgrades, the OpenZeppelin SDK xref:pattern.adoc#th
 
 [source,console]
 ----
-npm install @openzeppelin/upgrades@2.4.0
+npm install @openzeppelin/upgrades
 ----
 
 Now, let's write our exchange contract in `contracts/TokenExchange.sol`, using an _initializer_ to set its initial state:


### PR DESCRIPTION
Remove version `npm install @openzeppelin/upgrades@2.4.0` as `@openzeppelin/upgrades@2.4.0` doesn't exist and to use the latest version.

Raised in the forum: https://forum.openzeppelin.com/t/writing-upgradable-contracts/1820