### PR TITLE
Switch to identifying contracts by full path

### DIFF
--- a/packages/cli/src/models/compiler/solidity/SolidityContractsCompiler.ts
+++ b/packages/cli/src/models/compiler/solidity/SolidityContractsCompiler.ts
@@ -170,11 +170,11 @@ class SolidityContractsCompiler {
     });
   }
 
-  private _buildContractSchema(solcOutput: CompilerOutput, fileName: string, contractName: string): CompiledContract {
-    const output = solcOutput.contracts[fileName][contractName];
-    const source = solcOutput.sources[fileName];
-    fileName = path.basename(fileName);
-    const contract = this.contracts.find(aContract => aContract.fileName === fileName);
+  private _buildContractSchema(solcOutput: CompilerOutput, filePath: string, contractName: string): CompiledContract {
+    const output = solcOutput.contracts[filePath][contractName];
+    const source = solcOutput.sources[filePath];
+    const fileName = path.basename(filePath);
+    const contract = this.contracts.find(aContract => aContract.filePath === filePath);
 
     return {
       fileName,


### PR DESCRIPTION
The build in https://github.com/OpenZeppelin/openzeppelin-sdk/commit/855c2ad6a0f43737dfeb6bf98a99c00448c88c31 failed due to corrupted JSON artifacts. This was caused by writing the artifacts of two separate contracts into the same file concurrently, which itself was caused by using the basename instead of the full path to the Solidity files.