### PR TITLE
Restrict version range of Upgrades allowed to be used with CLI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -59,7 +59,7 @@
     "@openzeppelin/resolver-engine-core": "^0.3.3",
     "@openzeppelin/resolver-engine-imports-fs": "^0.3.3",
     "@openzeppelin/test-environment": "^0.1.0",
-    "@openzeppelin/upgrades": "^2.6.0",
+    "@openzeppelin/upgrades": "~2.6.0",
     "@types/fs-extra": "^7.0.0",
     "@types/npm": "^2.0.29",
     "@types/semver": "^5.5.0",


### PR DESCRIPTION
The current version ranges allow an installation of `@openzeppelin/cli` to use a newer version of `@openzeppelin/upgrades`. Since we don't test these combinations, we feel it would be best to restrict the allowed version range.