### PR TITLE
Update gsn-dapp.adoc remove unused var

### DIFF
--- a/packages/docs/modules/ROOT/pages/gsn-dapp.adoc
+++ b/packages/docs/modules/ROOT/pages/gsn-dapp.adoc
@@ -187,7 +187,6 @@ function App() {
   // load Counter Instance
   const [counterInstance, setCounterInstance] = useState(undefined);
 
-  let deployedNetwork = undefined;
   if (
     !counterInstance &&
     context &&


### PR DESCRIPTION
Fix: `Line 20:7:  'deployedNetwork' is assigned a value but never used  no-unused-vars`
Remove `let deployedNetwork = undefined;` as not used.
Declared where used in an if: `const deployedNetwork = counterJSON.networks[context.networkId.toString()];`