### PR TITLE
Adds tests timeout to prevent CI from failing

### DIFF
--- a/packages/cli/test/scripts/update.test.js
+++ b/packages/cli/test/scripts/update.test.js
@@ -476,7 +476,7 @@ describe('update script', function() {
           implementation: this.withLibraryImplV2Address,
         });
       });
-    });
+    }).timeout(5000);
   };
 
   const shouldHandleUpdateOnDependency = function() {
@@ -613,7 +613,7 @@ describe('update script', function() {
           .methods.version()
           .call()).should.eq('1.2.0');
       });
-    });
+    }).timeout(5000);
   };
 
   describe('on application contract', function() {


### PR DESCRIPTION
Some functions fail to execute during the default timeout of `2000` ms. This PR bumps timeout for them to `5000` ms.

```
1) update script
       on dependency contract
         updating on dependency
           "before each" hook: setup for "should upgrade the version of all proxies":
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/home/circleci/openzeppelin/packages/cli/test/scripts/update.test.js)

"should not attempt to upgrade a minimal proxy":
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/c/Users/andre/Documents/projects/forum/openzeppelin-sdk/packages/cli/test/scripts/update.test.js)
```