### PR TITLE
Add tuple support in interactive prompts

### DIFF
--- a/packages/cli/contracts/mocks/ImplV1.sol
+++ b/packages/cli/contracts/mocks/ImplV1.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
 
 import "./Libraries.sol";
 import "mock-stdlib/contracts/GreeterImpl.sol";
@@ -8,6 +9,8 @@ contract ImplV1 {
   uint256[] public numbers;
 
   event InitializeEvent(uint256 value);
+
+  struct MyTuple { uint256 value; string text; }
 
   function initialize(uint256 _value) public {
     value = _value;
@@ -37,6 +40,10 @@ contract ImplV1 {
 
   function sayNumbers() public view returns (uint256[] memory) {
     return numbers;
+  }
+
+  function echoTuple(MyTuple memory t) public pure returns (MyTuple memory) {
+    return t;
   }
 
   function doesNotReturn() public pure {

--- a/packages/cli/contracts/mocks/ImplV2.sol
+++ b/packages/cli/contracts/mocks/ImplV2.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
 
 import "./ImplV1.sol";
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "copy-files": "./scripts/copy-files.sh",
     "compile-ts": "rm -rf lib && tsc",
-    "compile-contracts": "rm -rf build/contracts && ../../bootstrap/node_modules/.bin/oz compile --solc-version 0.5.3 --evm-version constantinople",
+    "compile-contracts": "rm -rf build/contracts && ../../bootstrap/node_modules/.bin/oz compile --solc-version 0.5.14 --evm-version constantinople",
     "prepare": "npm run compile-contracts && npm run compile-ts && npm run copy-files && chmod 755 ./lib/bin/oz-cli.js",
     "test": "TS_NODE_PROJECT='tsconfig.test.json' mocha --require ts-node/register --recursive test",
     "gen-docs": "./scripts/gen-docs.sh",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -116,6 +116,7 @@
     "lodash.uniq": "^4.5.0",
     "lodash.uniqby": "^4.7.0",
     "lodash.uniqwith": "^4.5.0",
+    "lodash.zipwith": "^4.2.0",
     "npm-programmatic": "0.0.12",
     "rlp": "^2.2.3",
     "semver": "^5.5.0",

--- a/packages/cli/src/models/network/TransactionController.ts
+++ b/packages/cli/src/models/network/TransactionController.ts
@@ -11,7 +11,7 @@ import ProjectFile from '../files/ProjectFile';
 import NetworkFile from '../files/NetworkFile';
 import { describeEvents } from '../../utils/events';
 
-const { buildCallData, callDescription } = ABI;
+const { getABIFunction, callDescription } = ABI;
 
 interface ERC20TokenInfo {
   balance?: string;
@@ -137,7 +137,7 @@ export default class TransactionController {
     const { package: packageName, contract: contractName } = this.networkFile.getProxy(address);
     const contractManager = new ContractManager(this.projectFile);
     const contract = contractManager.getContractClass(packageName, contractName).at(address);
-    const { method } = buildCallData(contract, methodName, methodArgs);
+    const method = getABIFunction(contract, methodName, methodArgs);
 
     return { contract, method };
   }

--- a/packages/cli/src/prompts/method-params.ts
+++ b/packages/cli/src/prompts/method-params.ts
@@ -59,18 +59,22 @@ function getCommandProps(
     return {
       ...accum,
       [arg.name]: {
-        message: arg.name ? `${arg.name} (${arg.type}):` : `(${arg.type}):`,
+        message: arg.name ? `${arg.name} (${arg.type}):` : `(${arg.type}):`, // TODO: better description for tuples
         type: 'input',
         when: () => !methodArgs || !methodArgs[index],
-        validate: input => {
+        validate: (input: string) => {
           try {
-            parseArg(input, arg.type);
+            parseArg(input, arg);
             return true;
           } catch (err) {
-            return `${err.message}. Enter a valid ${arg.type} such as: ${getPlaceholder(arg)}.`;
+            const placeholder = getPlaceholder(arg);
+            const msg = placeholder
+              ? `Enter a valid ${arg.type} such as: ${getPlaceholder(arg)}`
+              : `Enter a valid ${arg.type}`;
+            return `${err.message}. ${msg}.`;
           }
         },
-        normalize: input => parseArg(input, arg.type),
+        normalize: input => parseArg(input, arg),
       },
     };
   }, {});

--- a/packages/cli/src/prompts/method-params.ts
+++ b/packages/cli/src/prompts/method-params.ts
@@ -3,7 +3,7 @@ import pickBy from 'lodash.pickby';
 import isUndefined from 'lodash.isundefined';
 import negate from 'lodash.negate';
 
-import { parseMethodParams, parseArg } from '../utils/input';
+import { parseMethodParams, parseArg, getPlaceholder } from '../utils/input';
 import { promptIfNeeded, argsList, methodsList, InquirerQuestions } from './prompt';
 
 type PropsFn = (any) => InquirerQuestions;
@@ -97,31 +97,4 @@ function getCommandProps(
     },
     ...args,
   };
-}
-
-function getPlaceholder(type: string): string {
-  const ARRAY_TYPE_REGEX = /(.+)\[\d*\]$/; // matches array type identifiers like uint[] or byte[4]
-
-  if (type.match(ARRAY_TYPE_REGEX)) {
-    const arrayType = type.match(ARRAY_TYPE_REGEX)[1];
-    const itemPlaceholder = getPlaceholder(arrayType);
-    return `[${itemPlaceholder}, ${itemPlaceholder}]`;
-  } else if (
-    type.startsWith('uint') ||
-    type.startsWith('int') ||
-    type.startsWith('fixed') ||
-    type.startsWith('ufixed')
-  ) {
-    return '42';
-  } else if (type === 'bool') {
-    return 'true';
-  } else if (type === 'bytes') {
-    return '0xabcdef';
-  } else if (type === 'address') {
-    return '0x1df62f291b2e969fb0849d99d9ce41e2f137006e';
-  } else if (type === 'string') {
-    return 'Hello world';
-  } else {
-    return null;
-  }
 }

--- a/packages/cli/src/prompts/method-params.ts
+++ b/packages/cli/src/prompts/method-params.ts
@@ -67,7 +67,7 @@ function getCommandProps(
             parseArg(input, arg.type);
             return true;
           } catch (err) {
-            return `${err.message}. Enter a valid ${arg.type} such as: ${getPlaceholder(arg.type)}.`;
+            return `${err.message}. Enter a valid ${arg.type} such as: ${getPlaceholder(arg)}.`;
           }
         },
         normalize: input => parseArg(input, arg.type),

--- a/packages/cli/src/prompts/method-params.ts
+++ b/packages/cli/src/prompts/method-params.ts
@@ -4,7 +4,7 @@ import isUndefined from 'lodash.isundefined';
 import negate from 'lodash.negate';
 
 import { parseMethodParams, parseArg, getPlaceholder } from '../utils/input';
-import { promptIfNeeded, argsList, methodsList, InquirerQuestions } from './prompt';
+import { promptIfNeeded, argsList, methodsList, InquirerQuestions, argLabel } from './prompt';
 
 type PropsFn = (any) => InquirerQuestions;
 
@@ -59,7 +59,7 @@ function getCommandProps(
     return {
       ...accum,
       [arg.name]: {
-        message: arg.name ? `${arg.name} (${arg.type}):` : `(${arg.type}):`, // TODO: better description for tuples
+        message: argLabel(arg),
         type: 'input',
         when: () => !methodArgs || !methodArgs[index],
         validate: (input: string) => {

--- a/packages/cli/src/prompts/method-params.ts
+++ b/packages/cli/src/prompts/method-params.ts
@@ -3,7 +3,7 @@ import pickBy from 'lodash.pickby';
 import isUndefined from 'lodash.isundefined';
 import negate from 'lodash.negate';
 
-import { parseMethodParams, parseArg, getPlaceholder } from '../utils/input';
+import { parseMethodParams, parseArg, getSampleInput } from '../utils/input';
 import { promptIfNeeded, argsList, methodsList, InquirerQuestions, argLabel } from './prompt';
 
 type PropsFn = (any) => InquirerQuestions;
@@ -59,7 +59,7 @@ function getCommandProps(
     return {
       ...accum,
       [arg.name]: {
-        message: argLabel(arg),
+        message: `${argLabel(arg)}:`,
         type: 'input',
         when: () => !methodArgs || !methodArgs[index],
         validate: (input: string) => {
@@ -67,7 +67,7 @@ function getCommandProps(
             parseArg(input, arg);
             return true;
           } catch (err) {
-            const placeholder = getPlaceholder(arg);
+            const placeholder = getSampleInput(arg);
             const msg = placeholder ? `Enter a valid ${arg.type} such as: ${placeholder}` : `Enter a valid ${arg.type}`;
             return `${err.message}. ${msg}.`;
           }

--- a/packages/cli/src/prompts/method-params.ts
+++ b/packages/cli/src/prompts/method-params.ts
@@ -68,9 +68,7 @@ function getCommandProps(
             return true;
           } catch (err) {
             const placeholder = getPlaceholder(arg);
-            const msg = placeholder
-              ? `Enter a valid ${arg.type} such as: ${getPlaceholder(arg)}`
-              : `Enter a valid ${arg.type}`;
+            const msg = placeholder ? `Enter a valid ${arg.type} such as: ${placeholder}` : `Enter a valid ${arg.type}`;
             return `${err.message}. ${msg}.`;
           }
         },

--- a/packages/cli/src/prompts/prompt.ts
+++ b/packages/cli/src/prompts/prompt.ts
@@ -52,11 +52,14 @@ interface MethodOptions {
   constant?: boolean;
 }
 
-export interface MethodArg {
-  name: string;
+export interface MethodArgType {
   type: string;
   internalType?: string;
   components?: MethodArg[];
+}
+
+export interface MethodArg extends MethodArgType {
+  name: string;
 }
 
 export let DISABLE_INTERACTIVITY: boolean =

--- a/packages/cli/src/prompts/prompt.ts
+++ b/packages/cli/src/prompts/prompt.ts
@@ -4,7 +4,7 @@ import isEmpty from 'lodash.isempty';
 import groupBy from 'lodash.groupby';
 import difference from 'lodash.difference';
 import inquirer from 'inquirer';
-import { contractMethodsFromAbi, ContractMethodMutability as Mutability } from '@openzeppelin/upgrades';
+import { contractMethodsFromAbi, ContractMethodMutability as Mutability, ABI } from '@openzeppelin/upgrades';
 
 import Session from '../models/network/Session';
 import ConfigManager from '../models/config/ConfigManager';
@@ -53,7 +53,7 @@ interface MethodOptions {
 }
 
 export interface MethodArg {
-  name: string; 
+  name: string;
   type: string;
   internalType?: string;
   components?: MethodArg[];
@@ -180,7 +180,7 @@ export function methodsList(
   return contractMethods(contractFullName, constant, projectFile)
     .map(({ name, hasInitializer, inputs, selector }) => {
       const initializable = hasInitializer ? '* ' : '';
-      const args = inputs.map(({ name: inputName, type }) => (inputName ? `${inputName}: ${type}` : type));
+      const args = inputs.map(argLabel);
       const label = `${initializable}${name}(${args.join(', ')})`;
 
       return { name: label, value: { name, selector } };
@@ -194,6 +194,10 @@ export function methodsList(
         return 0;
       else if (!a.name.startsWith('*') && b.name.startsWith('*')) return 1;
     });
+}
+
+export function argLabel(arg : MethodArg) : string {
+  return arg.name ? `${arg.name}: ${ABI.getABIType(arg)}` : ABI.getABIType(arg);
 }
 
 // Returns an inquirer question with a list of arguments for a particular method

--- a/packages/cli/src/prompts/prompt.ts
+++ b/packages/cli/src/prompts/prompt.ts
@@ -52,6 +52,13 @@ interface MethodOptions {
   constant?: boolean;
 }
 
+export interface MethodArg {
+  name: string; 
+  type: string;
+  internalType?: string;
+  components?: MethodArg[];
+}
+
 export let DISABLE_INTERACTIVITY: boolean =
   !process.stdin.isTTY ||
   !!process.env.OPENZEPPELIN_NON_INTERACTIVE ||
@@ -195,7 +202,7 @@ export function argsList(
   methodIdentifier: string,
   constant?: Mutability,
   projectFile?: ProjectFile,
-): { name: string; type: string }[] {
+): MethodArg[] {
   const method = contractMethods(contractFullName, constant, projectFile).find(
     ({ name, selector }): any => selector === methodIdentifier || name === methodIdentifier,
   );

--- a/packages/cli/src/prompts/prompt.ts
+++ b/packages/cli/src/prompts/prompt.ts
@@ -196,7 +196,7 @@ export function methodsList(
     });
 }
 
-export function argLabel(arg : MethodArg) : string {
+export function argLabel(arg: MethodArg): string {
   return arg.name ? `${arg.name}: ${ABI.getABIType(arg)}` : ABI.getABIType(arg);
 }
 

--- a/packages/cli/src/prompts/prompt.ts
+++ b/packages/cli/src/prompts/prompt.ts
@@ -200,7 +200,7 @@ export function methodsList(
 }
 
 export function argLabel(arg: MethodArg): string {
-  return arg.name ? `${arg.name}: ${ABI.getABIType(arg)}` : ABI.getABIType(arg);
+  return arg.name ? `${arg.name}: ${ABI.getArgTypeLabel(arg)}` : ABI.getArgTypeLabel(arg);
 }
 
 // Returns an inquirer question with a list of arguments for a particular method

--- a/packages/cli/src/utils/input.ts
+++ b/packages/cli/src/utils/input.ts
@@ -238,3 +238,32 @@ export function validateSalt(salt: string, required = false) {
     throw new Error(`Invalid salt ${salt}, must be an uint256 value.`);
   }
 }
+
+export function getPlaceholder(type: string): string {
+  const ARRAY_TYPE_REGEX = /(.+)\[\d*\]$/; // matches array type identifiers like uint[] or byte[4]
+
+  if (type.match(ARRAY_TYPE_REGEX)) {
+    const arrayType = type.match(ARRAY_TYPE_REGEX)[1];
+    const itemPlaceholder = getPlaceholder(arrayType);
+    return `[${itemPlaceholder}, ${itemPlaceholder}]`;
+  } else if (
+    type.startsWith('uint') ||
+    type.startsWith('int') ||
+    type.startsWith('fixed') ||
+    type.startsWith('ufixed')
+  ) {
+    return '42';
+  } else if (type === 'bool') {
+    return 'true';
+  } else if (type === 'bytes') {
+    return '0xabcdef';
+  } else if (type === 'address') {
+    return '0x1df62f291b2e969fb0849d99d9ce41e2f137006e';
+  } else if (type === 'string') {
+    return 'Hello world';
+  } else if (type === 'tuple') {
+    return null;
+  } else {
+    return null;
+  }
+}

--- a/packages/cli/src/utils/input.ts
+++ b/packages/cli/src/utils/input.ts
@@ -1,7 +1,7 @@
 import BN from 'bignumber.js';
 import flattenDeep from 'lodash.flattendeep';
 import { encodeParams, Loggy, ZWeb3 } from '@openzeppelin/upgrades';
-import { MethodArg } from '../prompts/prompt';
+import { MethodArgType } from '../prompts/prompt';
 import zipWith from 'lodash.zipwith';
 
 // TODO: Deprecate in favor of a combination of parseArg and parseArray
@@ -48,7 +48,7 @@ function quoteArguments(args: string) {
   return args;
 }
 
-export function parseArg(input: string | string[], { type, components }: Pick<MethodArg, 'type' | 'components'>): any {
+export function parseArg(input: string | string[], { type, components }: MethodArgType): any {
   const TRUE_VALUES = ['y', 'yes', 't', 'true', '1'];
   const FALSE_VALUES = ['n', 'no', 'f', 'false', '0'];
   const ARRAY_TYPE_REGEX = /(.+)\[\d*\]$/; // matches array type identifiers like uint[] or byte[4]
@@ -251,13 +251,13 @@ export function validateSalt(salt: string, required = false) {
   }
 }
 
-export function getPlaceholder(arg: Pick<MethodArg, 'type' | 'components'>): string {
+export function getSampleInput(arg: MethodArgType): string | null {
   const ARRAY_TYPE_REGEX = /(.+)\[\d*\]$/; // matches array type identifiers like uint[] or byte[4]
   const { type, components } = arg;
 
   if (type.match(ARRAY_TYPE_REGEX)) {
     const arrayType = type.match(ARRAY_TYPE_REGEX)[1];
-    const itemPlaceholder = getPlaceholder({ type: arrayType });
+    const itemPlaceholder = getSampleInput({ type: arrayType });
     return `[${itemPlaceholder}, ${itemPlaceholder}]`;
   } else if (
     type.startsWith('uint') ||
@@ -275,7 +275,7 @@ export function getPlaceholder(arg: Pick<MethodArg, 'type' | 'components'>): str
   } else if (type === 'string') {
     return 'Hello world';
   } else if (type === 'tuple' && components) {
-    return `(${components.map(c => getPlaceholder(c)).join(', ')})`;
+    return `(${components.map(c => getSampleInput(c)).join(', ')})`;
   } else if (type === 'tuple') {
     return `(Hello world, 42)`;
   } else {

--- a/packages/cli/src/utils/input.ts
+++ b/packages/cli/src/utils/input.ts
@@ -1,6 +1,7 @@
 import BN from 'bignumber.js';
 import flattenDeep from 'lodash.flattendeep';
 import { encodeParams, Loggy, ZWeb3 } from '@openzeppelin/upgrades';
+import { MethodArg } from '../prompts/prompt';
 
 // TODO: Deprecate in favor of a combination of parseArg and parseArray
 export function parseArgs(args: string): string[] | never {
@@ -239,12 +240,13 @@ export function validateSalt(salt: string, required = false) {
   }
 }
 
-export function getPlaceholder(type: string): string {
+export function getPlaceholder(arg: Pick<MethodArg, 'type' | 'components'>): string {
   const ARRAY_TYPE_REGEX = /(.+)\[\d*\]$/; // matches array type identifiers like uint[] or byte[4]
+  const { type, components } = arg;
 
   if (type.match(ARRAY_TYPE_REGEX)) {
     const arrayType = type.match(ARRAY_TYPE_REGEX)[1];
-    const itemPlaceholder = getPlaceholder(arrayType);
+    const itemPlaceholder = getPlaceholder({ type: arrayType });
     return `[${itemPlaceholder}, ${itemPlaceholder}]`;
   } else if (
     type.startsWith('uint') ||
@@ -261,8 +263,10 @@ export function getPlaceholder(type: string): string {
     return '0x1df62f291b2e969fb0849d99d9ce41e2f137006e';
   } else if (type === 'string') {
     return 'Hello world';
-  } else if (type === 'tuple') {
-    return null;
+  } else if (type === 'tuple' && components) {
+    return `[${components.map(c => getPlaceholder(c)).join(', ')}]`;
+  } else if (type === 'tuple') { 
+    return `[Hello world, 42]`;
   } else {
     return null;
   }

--- a/packages/cli/test/prompts/prompt.test.js
+++ b/packages/cli/test/prompts/prompt.test.js
@@ -257,7 +257,7 @@ describe('prompt', function() {
           it('returns an array of method arguments names', function() {
             const args = argsList('Greeter', 'greet(string)', Mutability.NotConstant, this.projectFile);
             args.should.be.an('array');
-            args[0].should.deep.equal({ name: 'who', type: 'string' });
+            args[0].should.deep.include({ name: 'who', type: 'string' });
           });
         });
 
@@ -265,7 +265,7 @@ describe('prompt', function() {
           it('returns an array of method arguments names', function() {
             const args = argsList('Greeter', 'greetings(uint256)', Mutability.Constant, this.projectFile);
             args.should.be.an('array');
-            args[0].should.deep.equal({ name: '#0', type: 'uint256' });
+            args[0].should.deep.include({ name: '#0', type: 'uint256' });
           });
         });
       });

--- a/packages/cli/test/scripts/call.test.js
+++ b/packages/cli/test/scripts/call.test.js
@@ -220,6 +220,24 @@ describe('call script', function() {
           this.logs.infos[this.logs.infos.length - 1].should.eq(`Method 'sayNumbers' returned: [1,2,3]`);
         });
       });
+
+      context('when the method takes and returns a struct', function() {
+        it('calls the method and logs the struct', async function() {
+          const proxyAddress = this.networkFile.getProxies({
+            contract: 'Impl',
+          })[0].address;
+          await call({
+            network,
+            txParams,
+            networkFile: this.networkFile,
+            proxyAddress,
+            methodName: 'echoTuple((uint256,string))',
+            methodArgs: [['42','Hello']],
+          });
+
+          this.logs.infos[this.logs.infos.length - 1].should.eq(`Method 'echoTuple((uint256,string))' returned: [42,Hello]`);
+        });
+      });
     });
   });
 });

--- a/packages/cli/test/scripts/call.test.js
+++ b/packages/cli/test/scripts/call.test.js
@@ -232,10 +232,12 @@ describe('call script', function() {
             networkFile: this.networkFile,
             proxyAddress,
             methodName: 'echoTuple((uint256,string))',
-            methodArgs: [['42','Hello']],
+            methodArgs: [['42', 'Hello']],
           });
 
-          this.logs.infos[this.logs.infos.length - 1].should.eq(`Method 'echoTuple((uint256,string))' returned: [42,Hello]`);
+          this.logs.infos[this.logs.infos.length - 1].should.eq(
+            `Method 'echoTuple((uint256,string))' returned: [42,Hello]`,
+          );
         });
       });
     });

--- a/packages/cli/test/utils/input.test.js
+++ b/packages/cli/test/utils/input.test.js
@@ -157,7 +157,10 @@ describe('input', function() {
 
     context.skip('pending', function() {
       itParses('[1,2,3]', 'uint256[][]', [['1', '2', '3']]);
-      itParses('[1,2],[3,4]', 'uint256[][]', [['1', '2'], ['3', '4']]);
+      itParses('[1,2],[3,4]', 'uint256[][]', [
+        ['1', '2'],
+        ['3', '4'],
+      ]);
     });
   });
 

--- a/packages/cli/test/utils/input.test.js
+++ b/packages/cli/test/utils/input.test.js
@@ -3,7 +3,7 @@ require('../setup');
 
 const expect = require('chai').expect;
 
-import { parseArgs, parseMethodParams, parseArray, parseArg, getPlaceholder } from '../../src/utils/input';
+import { parseArgs, parseMethodParams, parseArray, parseArg, getSampleInput } from '../../src/utils/input';
 
 describe('input', function() {
   describe('parseArgs', function() {
@@ -214,10 +214,10 @@ describe('input', function() {
     it('should init with specific function and args', testFn({ init: 'foo', args: '20' }, 'foo', ['20']));
   });
 
-  describe('getPlaceholder', function() {
-    const testType = (type, expected) => () => getPlaceholder({ type }).should.eq(expected);
+  describe('getSampleInput', function() {
+    const testType = (type, expected) => () => getSampleInput({ type }).should.eq(expected);
     const testTuple = (components, expected) => () =>
-      getPlaceholder({ type: 'tuple', components: components.map(c => ({ type: c })) }).should.eq(expected);
+      getSampleInput({ type: 'tuple', components: components.map(c => ({ type: c })) }).should.eq(expected);
 
     it('handles dynamic arrays', testType('uint256[]', '[42, 42]'));
     it('handles static arrays', testType('uint256[3]', '[42, 42]'));

--- a/packages/cli/test/utils/input.test.js
+++ b/packages/cli/test/utils/input.test.js
@@ -146,9 +146,9 @@ describe('input', function() {
     itParses('foo', 'unknown', 'foo');
 
     itParsesTuple('42, foo', ['uint256', 'string'], ['42', 'foo']);
-    itParsesTuple('[42, foo]', ['uint256', 'string'], ['42', 'foo']);
-    itParsesTuple('[-1e3, foo]', ['uint256', 'string'], ['-1000', 'foo']);
-    itParsesTuple('[42, "foo, bar"]', ['uint256', 'string'], ['42', 'foo, bar']);
+    itParsesTuple('(42, foo)', ['uint256', 'string'], ['42', 'foo']);
+    itParsesTuple('(-1e3, foo)', ['uint256', 'string'], ['-1000', 'foo']);
+    itParsesTuple('(42, "foo, bar")', ['uint256', 'string'], ['42', 'foo, bar']);
     itParsesTuple('42', ['uint256'], ['42']);
     itParsesTuple('foo', ['string'], ['foo']);
 
@@ -222,7 +222,7 @@ describe('input', function() {
     it('handles dynamic arrays', testType('uint256[]', '[42, 42]'));
     it('handles static arrays', testType('uint256[3]', '[42, 42]'));
     it('handles dynamic string arrays', testType('string[]', '[Hello world, Hello world]'));
-    it('handles tuples of primitive types', testTuple(['uint256', 'string'], '[42, Hello world]'));
-    it('handles tuples of unknown components', testType('tuple', '[Hello world, 42]'));
+    it('handles tuples of primitive types', testTuple(['uint256', 'string'], '(42, Hello world)'));
+    it('handles tuples of unknown components', testType('tuple', '(Hello world, 42)'));
   });
 });

--- a/packages/cli/test/utils/input.test.js
+++ b/packages/cli/test/utils/input.test.js
@@ -3,7 +3,7 @@ require('../setup');
 
 const expect = require('chai').expect;
 
-import { parseArgs, parseMethodParams, parseArray, parseArg } from '../../src/utils/input';
+import { parseArgs, parseMethodParams, parseArray, parseArg, getPlaceholder } from '../../src/utils/input';
 
 describe('input', function() {
   describe('parseArgs', function() {
@@ -196,5 +196,19 @@ describe('input', function() {
     it('should init when args is set', testFn({ args: '20' }, defaulMethodName, ['20']));
     it('should init with specific function', testFn({ init: 'foo' }, 'foo', []));
     it('should init with specific function and args', testFn({ init: 'foo', args: '20' }, 'foo', ['20']));
+  });
+
+  describe('getPlaceholder', function() {
+    const testType = (type, expected) => 
+      () => getPlaceholder({ type }).should.eq(expected);
+    const testTuple = (components, expected) => 
+      () => getPlaceholder({ type: 'tuple', components: components.map(c => ({ type: c }))})
+        .should.eq(expected);
+
+    it('handles dynamic arrays', testType('uint256[]', '[42, 42]'));
+    it('handles static arrays', testType('uint256[3]', '[42, 42]'));
+    it('handles dynamic string arrays', testType('string[]', '[Hello world, Hello world]'));
+    it('handles tuples of primitive types', testTuple(['uint256', 'string'], '[42, Hello world]'));
+    it('handles tuples of unknown components', testType('tuple', '[Hello world, 42]'));
   });
 });

--- a/packages/lib/src/artifacts/Contract.ts
+++ b/packages/lib/src/artifacts/Contract.ts
@@ -4,7 +4,7 @@ import ContractAST from '../utils/ContractAST';
 import { StorageLayoutInfo } from '../validations/Storage';
 import { TransactionReceipt } from 'web3-core';
 import { Contract as Web3Contract } from 'web3-eth-contract';
-import { getABIType } from '../utils/ABIs';
+import { getArgTypeLabel } from '../utils/ABIs';
 
 /*
  * Contract is an interface that extends Web3's Contract interface, adding some properties and methods like:
@@ -141,7 +141,7 @@ export function contractMethodsFromAbi(
     .filter(({ constant: isConstantMethod, type }) => isConstant === isConstantMethod && type === 'function')
     .map(method => {
       const { name, inputs } = method;
-      const selector = `${name}(${inputs.map(getABIType).join(',')})`;
+      const selector = `${name}(${inputs.map(getArgTypeLabel).join(',')})`;
       const infoFromAst = methodsFromAst.find(({ selector: selectorFromAst }) => selectorFromAst === selector);
       const modifiers = infoFromAst ? infoFromAst.modifiers : [];
       const initializer = modifiers.find(({ modifierName }) => modifierName.name === 'initializer');

--- a/packages/lib/src/artifacts/Contract.ts
+++ b/packages/lib/src/artifacts/Contract.ts
@@ -4,6 +4,7 @@ import ContractAST from '../utils/ContractAST';
 import { StorageLayoutInfo } from '../validations/Storage';
 import { TransactionReceipt } from 'web3-core';
 import { Contract as Web3Contract } from 'web3-eth-contract';
+import { getABIType } from '../utils/ABIs';
 
 /*
  * Contract is an interface that extends Web3's Contract interface, adding some properties and methods like:
@@ -140,7 +141,7 @@ export function contractMethodsFromAbi(
     .filter(({ constant: isConstantMethod, type }) => isConstant === isConstantMethod && type === 'function')
     .map(method => {
       const { name, inputs } = method;
-      const selector = `${name}(${inputs.map(({ type }) => type)})`;
+      const selector = `${name}(${inputs.map(getABIType).join(',')})`;
       const infoFromAst = methodsFromAst.find(({ selector: selectorFromAst }) => selectorFromAst === selector);
       const modifiers = infoFromAst ? infoFromAst.modifiers : [];
       const initializer = modifiers.find(({ modifierName }) => modifierName.name === 'initializer');

--- a/packages/lib/src/utils/ABIs.ts
+++ b/packages/lib/src/utils/ABIs.ts
@@ -146,6 +146,6 @@ export function callDescription(method: any, args: string[]): string {
 export default {
   buildCallData,
   getABIFunction,
-  getABIType: getArgTypeLabel,
+  getArgTypeLabel,
   callDescription,
 };

--- a/packages/lib/src/utils/ABIs.ts
+++ b/packages/lib/src/utils/ABIs.ts
@@ -66,7 +66,7 @@ export function getABIFunction(contract: Contract, methodName: string, args: any
   }
 }
 
-export function getABIType(arg : any) : string {
+export function getABIType(arg: any): string {
   if (arg.type === 'tuple') {
     return `(${arg.components.map(getABIType).join(',')})`;
   } else {

--- a/packages/lib/src/utils/ABIs.ts
+++ b/packages/lib/src/utils/ABIs.ts
@@ -76,7 +76,7 @@ export function getABIType(arg : any) : string {
 
 function tryGetTargetFunction(contract: Contract, methodName: string, args: string[] | undefined): FunctionInfo {
   // Match foo(uint256,string) as method name, and look for that in the ABI
-  const match: string[] = methodName.match(/^\s*(.+)\((.*)\)\s*$/);
+  const match: string[] = methodName.match(/^\s*(.+?)\((.*)\)\s*$/);
   if (match) {
     const name = match[1];
     const inputs = match[2].split(',').map(arg => ({ type: arg }));

--- a/packages/lib/src/utils/ABIs.ts
+++ b/packages/lib/src/utils/ABIs.ts
@@ -66,6 +66,14 @@ export function getABIFunction(contract: Contract, methodName: string, args: any
   }
 }
 
+export function getABIType(arg : any) : string {
+  if (arg.type === 'tuple') {
+    return `(${arg.components.map(getABIType).join(',')})`;
+  } else {
+    return arg.type;
+  }
+}
+
 function tryGetTargetFunction(contract: Contract, methodName: string, args: string[] | undefined): FunctionInfo {
   // Match foo(uint256,string) as method name, and look for that in the ABI
   const match: string[] = methodName.match(/^\s*(.+)\((.*)\)\s*$/);
@@ -137,5 +145,6 @@ export function callDescription(method: any, args: string[]): string {
 export default {
   buildCallData,
   getABIFunction,
+  getABIType,
   callDescription,
 };

--- a/packages/lib/src/utils/ABIs.ts
+++ b/packages/lib/src/utils/ABIs.ts
@@ -12,6 +12,7 @@ export interface CalldataInfo {
 interface InputInfo {
   name?: string;
   type: string;
+  components?: InputInfo[];
 }
 
 interface FunctionInfo {
@@ -66,9 +67,9 @@ export function getABIFunction(contract: Contract, methodName: string, args: any
   }
 }
 
-export function getABIType(arg: any): string {
+export function getArgTypeLabel(arg: InputInfo): string {
   if (arg.type === 'tuple') {
-    return `(${arg.components.map(getABIType).join(',')})`;
+    return `(${arg.components.map(getArgTypeLabel).join(',')})`;
   } else {
     return arg.type;
   }
@@ -145,6 +146,6 @@ export function callDescription(method: any, args: string[]): string {
 export default {
   buildCallData,
   getABIFunction,
-  getABIType,
+  getABIType: getArgTypeLabel,
   callDescription,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7416,6 +7416,7 @@ lodash.uniq@^4.5.0:
 lodash.uniqby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
+  integrity sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=
 
 lodash.uniqwith@^4.5.0:
   version "4.5.0"
@@ -7432,6 +7433,7 @@ lodash.without@^4.4.0:
 lodash.zipwith@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.zipwith/-/lodash.zipwith-4.2.0.tgz#afacf03fd2f384af29e263c3c6bda3b80e3f51fd"
+  integrity sha1-r6zwP9LzhK8p4mPDxr2juA4/Uf0=
 
 lodash@4.17.14:
   version "4.17.14"


### PR DESCRIPTION
Fixes #1330. Tuples can be entered as comma separated, or as comma separated enclosed in parenthesis.

![Screenshot from 2019-12-13 17-26-22](https://user-images.githubusercontent.com/429604/70829926-bd522580-1dcd-11ea-8546-21de4b334efb.png)
