### PR TITLE
Load gas and gasPrice from networkConfig

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -151,6 +151,7 @@
     "ganache-cli": "^6.3.0",
     "husky": "^2.7.0",
     "lint-staged": "4.3.0",
+    "lodash.isnil": "^4.0.0",
     "lodash.mapkeys": "^4.6.0",
     "lodash.random": "^3.2.0",
     "mocha": "^6.2.2",

--- a/packages/cli/src/models/config/ConfigManager.ts
+++ b/packages/cli/src/models/config/ConfigManager.ts
@@ -3,6 +3,8 @@ import TruffleConfig from './TruffleConfig';
 import Session from '../network/Session';
 import NetworkConfig from './NetworkConfig';
 
+import pick from 'lodash.pick';
+
 const ConfigManager = {
   config: undefined,
 
@@ -38,6 +40,7 @@ const ConfigManager = {
       await ZWeb3.checkNetworkId(network.networkId);
       const txParams = {
         from: ZWeb3.toChecksumAddress(from || artifactDefaults.from || (await ZWeb3.defaultAccount())),
+        ...pick(artifactDefaults, ['gas', 'gasPrice']),
       };
 
       return { network: await ZWeb3.getNetworkName(), txParams };

--- a/packages/cli/src/models/config/ConfigManager.ts
+++ b/packages/cli/src/models/config/ConfigManager.ts
@@ -4,6 +4,8 @@ import Session from '../network/Session';
 import NetworkConfig from './NetworkConfig';
 
 import pick from 'lodash.pick';
+import pickBy from 'lodash.pickby';
+import isNil from 'lodash.isnil';
 
 const ConfigManager = {
   config: undefined,
@@ -40,7 +42,7 @@ const ConfigManager = {
       await ZWeb3.checkNetworkId(network.networkId);
       const txParams = {
         from: ZWeb3.toChecksumAddress(from || artifactDefaults.from || (await ZWeb3.defaultAccount())),
-        ...pick(artifactDefaults, ['gas', 'gasPrice']),
+        ...pickBy(pick(artifactDefaults, ['gas', 'gasPrice']), x => !isNil(x)),
       };
 
       return { network: await ZWeb3.getNetworkName(), txParams };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7290,6 +7290,7 @@ lodash.ismatch@^4.4.0:
 lodash.isnil@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/lodash.isnil/-/lodash.isnil-4.0.0.tgz#49e28cd559013458c814c5479d3c663a21bfaa6c"
+  integrity sha1-SeKM1VkBNFjIFMVHnTxmOiG/qmw=
 
 lodash.isnull@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Fixes https://github.com/OpenZeppelin/openzeppelin-sdk/issues/1227

The change itself is rather simple: the only thing I'm unsure is whether we should test this as a unit test, integration, or not at all.

That said, I want to discuss my findings while looking into this issue to provide some context that may help inform future decisions.

`lib` defines a `TxParams` object that is passed around when sending transactions and serves as a default for these. This object is populated by `ConfigManager` from the network configuration file, and before this PR, it only includes `from`. 

Because of this, I was surprised to see that the correct values for `gas` are nonetheless used in all transactions: it turns out `lib/utils/Transactions` handles a null value for `gas` by loading it from `Contracts.getArtifactsDefault`, which acts as a sort of global store of configuration. Notice that it was `ConfigManager` who called `Contracts.setArtifactsDefaults`, duplicating these values.

The bug surfaced in `transfer` because this is the first instance of the SDK sending transactions that are not contract function calls. On those, because the gas price was never specified, web3 used the default one that is set when creating the contract objects.

There seems to be a tension here between global configuration that is accessed directly (either via the `Contracts.setDefaultArtifacts` or the implicit default values used in the web3 objects), and explicit configuration objects that are passed down the call stack. We may want to revisit this at some point.

From the description above, it should be clear that `gas` and `gasPrice` were always obtained from `getArtifactDefault`, when available. Because of this, I'm relatively confident that this PR will not break current behaviour.