### PR TITLE
Fix false positive warning of library import

### DIFF
--- a/packages/cli/src/interface/ValidationLogger.ts
+++ b/packages/cli/src/interface/ValidationLogger.ts
@@ -54,15 +54,16 @@ export default class ValidationLogger {
   }
 
   public logImportsVanillaContracts(vanillaContracts: string[] | null): void {
-    if (!vanillaContracts) return;
-    Loggy.noSpin.warn(
-      __filename,
-      'logImportsVanillaContracts',
-      `validation-imports-vanilla-contracts`,
-      `- Contract ${this.contractName} imports ${vanillaContracts.join(
-        ', ',
-      )} from @openzeppelin/contracts. Use @openzeppelin/contracts-ethereum-package instead. See ${VANILLA_CONTRACTS_LINK}.`,
-    );
+    if (!isEmpty(vanillaContracts)) {
+      Loggy.noSpin.warn(
+        __filename,
+        'logImportsVanillaContracts',
+        `validation-imports-vanilla-contracts`,
+        `- Contract ${this.contractName} imports ${vanillaContracts.join(
+          ', ',
+        )} from @openzeppelin/contracts. Use @openzeppelin/contracts-ethereum-package instead. See ${VANILLA_CONTRACTS_LINK}.`,
+      );
+    }
   }
 
   public logHasSelfDestruct(hasSelfDestruct: boolean): void {

--- a/packages/cli/test/interface/ValidationLogger.test.js
+++ b/packages/cli/test/interface/ValidationLogger.test.js
@@ -55,6 +55,11 @@ describe('ValidationLogger', function() {
       validationLogger().log({ importsVanillaContracts: ['Foo.sol', 'Bar.sol'] });
       this.logs.warns[0].should.match(/@openzeppelin\/contracts/);
     });
+
+    it('does not log with no imports', async function() {
+      validationLogger().log({ importsVanillaContracts: [] });
+      this.logs.warns.length.should.equal(0);
+    });
   });
 
   describe('storage', function() {


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/OpenZeppelin/openzeppelin-sdk/pull/1335 that causes **all** contracts to emit the following warning on `create`:

>- Contract <name> imports  from @openzeppelin/contracts. Use @openzeppelin/contracts-ethereum-package instead. See https://docs.openzeppelin.com/sdk/2.6/linking#linking-the-contracts-ethereum-package.

On `lib`, `importsVanillaContracts` return type is `string[] | undefined`. However, when `newValidationErrors` calls `lodash.difference`, a value of undefined is silently converted into the empty array:

```javascript
> difference(null, null)
[]
```

This is handled correctly in `validationPasses`, which uses `lodash.isEmpty`, but not on `ValidationLogger`, which just tests the result as a truthy value. Because **empty arrays are truthy**, unlike `undefined`, the warning is emitted.

The quick fix is to use `isEmpty`, like `logUninitializedBaseContracts` does, but I'd suggest either dropping the `string[] | undefined` semantics altogether and treating the empty array as a lack of warnings, or changing how `difference` works.