### PR TITLE
Fix eslint config for CLI

### DIFF
--- a/packages/cli/.eslintrc.js
+++ b/packages/cli/.eslintrc.js
@@ -1,8 +1,6 @@
 module.exports = {
-  extends: [
-      '../../.eslintrc.base.js',
-  ],
+  extends: ['../../.eslintrc.base.js'],
   rules: {
-    '@typescript-eslint/explicit-function-return-type': false,
+    '@typescript-eslint/explicit-function-return-type': 'off',
   },
 };


### PR DESCRIPTION
As stated in [eslint config](https://eslint.org/docs/4.0.0/user-guide/configuring#configuring-rules) rules all the value can be either numeric or literal,  no booleans allowed.
```
"off" or 0 - turn the rule off
"warn" or 1 - turn the rule on as a warning (doesn't affect exit code)
"error" or 2 - turn the rule on as an error (exit code is 1 when triggered)
```