### PR TITLE
Stop interactive create or update on validation errors

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -33,7 +33,7 @@ const register: (program: any) => any = program =>
     .description(description)
     .option('--init [function]', `call function after creating contract. If none is given, 'initialize' will be used`)
     .option('--args <arg1, arg2, ...>', 'provide initialization arguments for your contract if required')
-    .option('--force', 'force creation even if contracts have local modifications')
+    .option('--force', 'ignore contracts validation errors')
     .option('--minimal', 'creates a cheaper but non-upgradeable instance instead, using a minimal proxy')
     .withNetworkOptions()
     .withSkipCompileOption()
@@ -62,7 +62,6 @@ async function commandActions(contractFullName: string, options: any): Promise<v
   await push.runActionIfNeeded(promptedContractFullName, network, {
     ...options,
     network: promptedNetwork,
-    force: true,
   });
 
   await action(promptedContractFullName, { ...options, network, txParams });

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -6,12 +6,9 @@ import add from './add';
 import push from '../scripts/push';
 import Session from '../models/network/Session';
 import { compile } from '../models/compiler/Compiler';
-import { fromContractFullName } from '../utils/naming';
 import Dependency from '../models/dependency/Dependency';
-import ProjectFile from '../models/files/ProjectFile';
 import ConfigManager from '../models/config/ConfigManager';
 import { promptIfNeeded, networksList, InquirerQuestions } from '../prompts/prompt';
-import NetworkFile from '../models/files/NetworkFile';
 import Telemetry from '../telemetry';
 
 const name = 'push';
@@ -94,20 +91,8 @@ async function runActionIfRequested(externalOptions: any): Promise<void> {
 }
 
 async function runActionIfNeeded(contractName: string, network: string, options: any): Promise<void> {
-  const { force, interactive, network: promptedNetwork } = options;
-  const projectFile = new ProjectFile();
-  const networkFile = new NetworkFile(projectFile, network);
-  const { contract: contractAlias, package: packageName } = fromContractFullName(contractName);
-
-  if (interactive) {
-    if (
-      force ||
-      (!packageName && !networkFile.hasContract(contractAlias)) ||
-      (packageName && !networkFile.hasDependency(packageName))
-    ) {
-      await action({ ...options, dontExitProcess: true, skipTelemetry: true });
-    }
-  }
+  if (!options.interactive) return;
+  await action({ ...options, dontExitProcess: true, skipTelemetry: true });
 }
 
 async function promptForDeployDependencies(

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -35,7 +35,7 @@ const register: (program: any) => any = program =>
     )
     .option('--args <arg1, arg2, ...>', 'provide initialization arguments for your contract if required')
     .option('--all', 'upgrade all contracts in the application')
-    .option('--force', 'force creation even if contracts have local modifications')
+    .option('--force', 'ignore contracts validation errors')
     .withNetworkOptions()
     .withSkipCompileOption()
     .withNonInteractiveOption()
@@ -51,7 +51,6 @@ async function commandActions(proxyReference: string, options: any): Promise<voi
   await push.runActionIfNeeded(null, network, {
     ...options,
     network: promptedNetwork,
-    force: true,
   });
 
   await action(proxyReference, { ...options, network, txParams });


### PR DESCRIPTION
The force flag was being passed to push from both create and upgrade to force pushing the implementation contracts. This caused the contracts to be pushed even if they had validation errors. This commit removes that flag so the create or upgrade fails if there are any errors.

Fixes #1348