### PR TITLE
Add url and path properties to network config

### DIFF
--- a/packages/cli/src/models/config/NetworkConfig.ts
+++ b/packages/cli/src/models/config/NetworkConfig.ts
@@ -13,8 +13,6 @@ interface ConfigInterface {
   networks: { [network: string]: Network };
   provider: Provider;
   buildDir: string;
-  // TODO: remove after managing compiler info in project.json
-  compilers?: CompilersInfo;
 }
 
 interface NetworkCamelCase<T> {
@@ -29,7 +27,7 @@ type NetworkId<T> = NetworkCamelCase<T> | NetworkSnakeCase<T> | (NetworkCamelCas
 
 type Network = {
   host: string;
-  port: number | string;
+  port?: number | string;
   protocol?: string;
   from?: number | string;
   gas?: number | string;
@@ -44,8 +42,6 @@ interface ArtifactDefaults {
 }
 
 type Provider = string | ((any) => any);
-// TODO: remove after managing compiler info in project.json
-type CompilersInfo = any;
 
 const NetworkConfig = {
   name: 'NetworkConfig',
@@ -62,10 +58,9 @@ const NetworkConfig = {
   getConfig(root: string = process.cwd()): ConfigInterface {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const zosConfigFile = require(`${root}/networks.js`);
-    const compilers = zosConfigFile.compilers || this.getDefaultCompilersProperties();
     const buildDir = `${root}/build/contracts`;
 
-    return { ...zosConfigFile, compilers, buildDir };
+    return { ...zosConfigFile, buildDir };
   },
 
   getBuildDir(): string {
@@ -114,20 +109,6 @@ const NetworkConfig = {
     const networkDefaults = omit(pick(network, defaults), isUndefined);
 
     return { ...configDefaults, ...networkDefaults };
-  },
-
-  getDefaultCompilersProperties(): CompilersInfo {
-    return {
-      vyper: {},
-      solc: {
-        settings: {
-          optimizer: {
-            enabled: false,
-            runs: 200,
-          },
-        },
-      },
-    };
   },
 
   createContractsDir(root: string): void {

--- a/packages/cli/test/config/NetworkConfig.test.js
+++ b/packages/cli/test/config/NetworkConfig.test.js
@@ -21,123 +21,121 @@ describe('NetworkConfig', function() {
 
   afterEach('cleanup files and folders', cleanupfn(tmpDir));
 
-  describe('methods', function() {
-    describe('#initialize', function() {
-      it('creates an empty contracts folder if missing', function() {
-        NetworkConfig.initialize(tmpDir);
+  describe('#initialize', function() {
+    it('creates an empty contracts folder if missing', function() {
+      NetworkConfig.initialize(tmpDir);
 
-        fs.existsSync(contractsDir).should.be.true;
-        fs.readdirSync(contractsDir, 'utf8').should.have.lengthOf(1);
-        fs.readdirSync(contractsDir, 'utf8').should.include('.gitkeep');
-      });
-
-      it('does not create an empty contracts folder if present', function() {
-        fs.mkdirSync(contractsDir, { recursive: true });
-        fs.writeFileSync(`${contractsDir}/Sample.sol`, '');
-        NetworkConfig.initialize(tmpDir);
-
-        fs.existsSync(contractsDir).should.be.true;
-        fs.readdirSync(contractsDir, 'utf8').should.have.lengthOf(1);
-        fs.readdirSync(contractsDir, 'utf8').should.include('Sample.sol');
-      });
-
-      it('creates a networks.js file if missing', function() {
-        NetworkConfig.initialize(tmpDir);
-
-        fs.existsSync(networkConfigPath).should.be.true;
-      });
-
-      it('does not create a networks.js file if present', function() {
-        fs.writeFileSync(networkConfigFile, '');
-        NetworkConfig.initialize(tmpDir);
-
-        fs.readFileSync(networkConfigPath, 'utf8').should.have.lengthOf(0);
-      });
+      fs.existsSync(contractsDir).should.be.true;
+      fs.readdirSync(contractsDir, 'utf8').should.have.lengthOf(1);
+      fs.readdirSync(contractsDir, 'utf8').should.include('.gitkeep');
     });
 
-    describe('#exists', function() {
-      context('when the networks.js file does not exist', function() {
-        it('returns false', function() {
-          NetworkConfig.exists(tmpDir).should.eq(false);
-        });
-      });
+    it('does not create an empty contracts folder if present', function() {
+      fs.mkdirSync(contractsDir, { recursive: true });
+      fs.writeFileSync(`${contractsDir}/Sample.sol`, '');
+      NetworkConfig.initialize(tmpDir);
 
-      context('when the networks.js file exists', function() {
-        it('returns true', function() {
-          NetworkConfig.initialize(tmpDir);
-          NetworkConfig.exists(tmpDir).should.eq(true);
-        });
-      });
+      fs.existsSync(contractsDir).should.be.true;
+      fs.readdirSync(contractsDir, 'utf8').should.have.lengthOf(1);
+      fs.readdirSync(contractsDir, 'utf8').should.include('Sample.sol');
     });
 
-    describe('#getConfig', function() {
-      it('setups the config', function() {
-        NetworkConfig.initialize(tmpDir);
-        const config = NetworkConfig.getConfig(networkConfigDir);
+    it('creates a networks.js file if missing', function() {
+      NetworkConfig.initialize(tmpDir);
 
-        config.should.have.all.keys('networks', 'compilers', 'buildDir');
-        config.should.not.have.key('network');
-        config.buildDir.should.eq(path.resolve(process.cwd(), tmpDir, 'build/contracts'));
-      });
+      fs.existsSync(networkConfigPath).should.be.true;
     });
 
-    describe('#loadNetworkConfig', function() {
-      context('when provided network does not exist', function() {
-        it('throws an error', function() {
-          NetworkConfig.initialize(tmpDir);
-          (() => NetworkConfig.loadNetworkConfig('non-existent', networkConfigDir)).should.throw(
-            /is not defined in your networks.js file/,
-          );
-        });
+    it('does not create a networks.js file if present', function() {
+      fs.writeFileSync(networkConfigFile, '');
+      NetworkConfig.initialize(tmpDir);
+
+      fs.readFileSync(networkConfigPath, 'utf8').should.have.lengthOf(0);
+    });
+  });
+
+  describe('#exists', function() {
+    it('returns false when the networks.js file does not exist', function() {
+      NetworkConfig.exists(tmpDir).should.eq(false);
+    });
+
+    it('returns true when the networks.js file exists', function() {
+      NetworkConfig.initialize(tmpDir);
+      NetworkConfig.exists(tmpDir).should.eq(true);
+    });
+  });
+
+  describe('#getConfig', function() {
+    it('setups the config', function() {
+      NetworkConfig.initialize(tmpDir);
+      const config = NetworkConfig.getConfig(networkConfigDir);
+
+      config.should.have.all.keys('networks', 'buildDir');
+      config.should.not.have.key('network');
+      config.buildDir.should.eq(path.resolve(process.cwd(), tmpDir, 'build/contracts'));
+    });
+  });
+
+  describe('#loadNetworkConfig', function() {
+    afterEach('stubs config', function() {
+      sinon.restore();
+    });
+
+    it('throws an error when provided network does not exist', function() {
+      NetworkConfig.initialize(tmpDir);
+      (() => NetworkConfig.loadNetworkConfig('non-existent', networkConfigDir)).should.throw(
+        /is not defined in your networks.js file/,
+      );
+    });
+
+    it('setups the current selected network config', function() {
+      NetworkConfig.initialize(tmpDir);
+      const config = NetworkConfig.getConfig(networkConfigDir);
+      const networkConfig = NetworkConfig.loadNetworkConfig('development', networkConfigDir);
+
+      networkConfig.provider.should.eq('http://localhost:8545');
+      networkConfig.artifactDefaults.should.include({
+        gas: 5000000,
+        gasPrice: 5000000000,
       });
+      networkConfig.should.deep.include(config);
+    });
 
-      context('when the network exists', function() {
-        it('setups the current selected network config', function() {
-          NetworkConfig.initialize(tmpDir);
-          const config = NetworkConfig.getConfig(networkConfigDir);
-          const networkConfig = NetworkConfig.loadNetworkConfig('development', networkConfigDir);
-
-          networkConfig.provider.should.eq('http://localhost:8545');
-          networkConfig.artifactDefaults.should.include({
-            gas: 5000000,
-            gasPrice: 5000000000,
-          });
-          networkConfig.should.deep.include(config);
-        });
-
-        context('when specifying a diferent provider', function() {
-          afterEach('stubs config', function() {
-            sinon.restore();
-          });
-
-          context('when specifying a function as provider', function() {
-            it('calls the function', function() {
-              const provider = () => 'returned provider';
-              sinon.stub(NetworkConfig, 'getConfig').returns({
-                networks: {
-                  local: { provider, host: 'localhost', port: '1324' },
-                },
-              });
-              NetworkConfig.initialize(tmpDir);
-              const networkConfig = NetworkConfig.loadNetworkConfig('local', networkConfigDir);
-              networkConfig.provider.should.eq('returned provider');
-            });
-          });
-
-          context('when specifying a different protocol', function() {
-            it('setups a different provider', function() {
-              sinon.stub(NetworkConfig, 'getConfig').returns({
-                networks: {
-                  local: { protocol: 'wss', host: 'localhost', port: '1324' },
-                },
-              });
-              NetworkConfig.initialize(tmpDir);
-              const networkConfig = NetworkConfig.loadNetworkConfig('local', networkConfigDir);
-              networkConfig.provider.should.eq('wss://localhost:1324');
-            });
-          });
-        });
+    it('setups a provider from a function', function() {
+      const provider = () => 'returned provider';
+      sinon.stub(NetworkConfig, 'getConfig').returns({
+        networks: { local: { provider, host: 'localhost', port: '1324' } },
       });
+      NetworkConfig.initialize(tmpDir);
+      const networkConfig = NetworkConfig.loadNetworkConfig('local', networkConfigDir);
+      networkConfig.provider.should.eq('returned provider');
+    });
+
+    it('setups a provider from URL parts', function() {
+      sinon.stub(NetworkConfig, 'getConfig').returns({
+        networks: { local: { protocol: 'wss', host: 'localhost', port: '1324', path: 'foo' } },
+      });
+      NetworkConfig.initialize(tmpDir);
+      const networkConfig = NetworkConfig.loadNetworkConfig('local', networkConfigDir);
+      networkConfig.provider.should.eq('wss://localhost:1324/foo');
+    });
+
+    it('setups a provider from just URL host', function() {
+      sinon.stub(NetworkConfig, 'getConfig').returns({
+        networks: { local: { host: 'localhost' } },
+      });
+      NetworkConfig.initialize(tmpDir);
+      const networkConfig = NetworkConfig.loadNetworkConfig('local', networkConfigDir);
+      networkConfig.provider.should.eq('http://localhost');
+    });
+
+    it('setups a provider from plain URL', function() {
+      sinon.stub(NetworkConfig, 'getConfig').returns({
+        networks: { local: { url: 'wss://localhost:1324/foo' } },
+      });
+      NetworkConfig.initialize(tmpDir);
+      const networkConfig = NetworkConfig.loadNetworkConfig('local', networkConfigDir);
+      networkConfig.provider.should.eq('wss://localhost:1324/foo');
     });
   });
 });


### PR DESCRIPTION
Add support for specifying an url entry with the full URL to the node. Also adds a new entry, path, that can be combined with host, protocol, and port, and makes port optional. Note that #1338 suggested accepting a path as part of the host, though this is not technically correct (hence the new path property).

Fixes #1338