### PR TITLE
Fix regular deploy issues with ZWeb3 initialization

### DIFF
--- a/packages/cli/src/commands/deploy/action.ts
+++ b/packages/cli/src/commands/deploy/action.ts
@@ -38,8 +38,7 @@ export async function action(params: Options & Args): Promise<void> {
     }
   }
 
-  const { network, txParams } =
-    process.env.NODE_ENV === 'test' ? params : await ConfigManager.initNetworkConfiguration(params);
+  const { network, txParams } = params;
 
   // Used for network preselection in subsequent runs.
   Session.setDefaultNetworkIfNeeded(network);

--- a/packages/cli/src/commands/deploy/spec.ts
+++ b/packages/cli/src/commands/deploy/spec.ts
@@ -110,6 +110,22 @@ export const options: Option[] = [
     },
   },
   {
+    format: '--timeout <timeout>',
+    description: `timeout in seconds for each transaction (default: ${DEFAULT_TX_TIMEOUT})`,
+  },
+  {
+    format: '-f, --from <address>',
+    description: 'sender for the contract creation transaction',
+    async postprocess(params) {
+      // Once we have all required params (network, timeout, from) we initialize the config.
+      if (process.env.NODE_ENV !== 'test') {
+        const { default: ConfigManager } = await import('../../models/config/ConfigManager');
+        const config = await ConfigManager.initNetworkConfiguration(params);
+        Object.assign(params, config);
+      }
+    },
+  },
+  {
     format: '--migrate-manifest',
     description: 'enable automatic migration of manifest format',
     async details(options: Options) {
@@ -127,14 +143,6 @@ export const options: Option[] = [
         };
       }
     },
-  },
-  {
-    format: '--timeout <timeout>',
-    description: `timeout in seconds for each transaction (default: ${DEFAULT_TX_TIMEOUT})`,
-  },
-  {
-    format: '-f, --from <address>',
-    description: 'sender for the contract creation transaction',
   },
   {
     format: '-k, --kind <kind>',

--- a/packages/cli/src/models/config/ConfigManager.ts
+++ b/packages/cli/src/models/config/ConfigManager.ts
@@ -9,7 +9,6 @@ import isNil from 'lodash.isnil';
 
 const ConfigManager = {
   config: undefined,
-  cache: undefined,
 
   initialize(root: string = process.cwd()): void {
     if (!TruffleConfig.exists() && !NetworkConfig.exists()) {
@@ -45,8 +44,7 @@ const ConfigManager = {
         ...pickBy(pick(artifactDefaults, ['gas', 'gasPrice']), x => !isNil(x)),
       };
 
-      this.cache = { network: await ZWeb3.getNetworkName(), txParams };
-      return this.cache;
+      return { network: await ZWeb3.getNetworkName(), txParams };
     } catch (error) {
       if (this.config && this.config.name === 'NetworkConfig') {
         const providerInfo = typeof provider === 'string' ? ` on ${provider}` : '';

--- a/packages/cli/src/register-command.ts
+++ b/packages/cli/src/register-command.ts
@@ -27,11 +27,13 @@ type Param = ParamSimple | ParamVariadic;
 interface ParamSimple {
   variadic?: false;
   details?: (params: object) => Promise<ParamDetails | undefined>;
+  postprocess?: (params: object) => Promise<void>;
 }
 
 interface ParamVariadic {
   variadic: true;
   details?: (params: object) => Promise<ParamDetails[]>;
+  postprocess?: (params: object) => Promise<void>;
 }
 
 export type Arg = Param & { name: string };
@@ -110,6 +112,7 @@ async function promptOrValidateAll(cmd: Command, spec: CommandSpec, params: Comm
     } else {
       await promptOrValidateSimple(name, param, params);
     }
+    await param.postprocess?.(params);
   }
 }
 

--- a/packages/cli/src/telemetry/send-to-firebase.ts
+++ b/packages/cli/src/telemetry/send-to-firebase.ts
@@ -3,7 +3,6 @@ import firebase from 'firebase/app';
 import 'firebase/auth';
 import 'firebase/firestore';
 
-import ConfigManager from '../models/config/ConfigManager';
 import { StringObject, UserEnvironment } from '.';
 
 const FIREBASE_CONFIG = {
@@ -20,24 +19,10 @@ interface Arguments {
   uuid: string;
   commandData: StringObject;
   userEnvironment: UserEnvironment;
-  userNetwork?: string;
 }
 
-async function getCanonicalNetworkName(network: string) {
-  const config = await ConfigManager.initNetworkConfiguration({ network });
-  if (config.network.match(/^dev-/)) {
-    return 'development';
-  } else {
-    return config.network;
-  }
-}
-
-process.once('message', async function({ uuid, commandData, userEnvironment, userNetwork }: Arguments) {
+process.once('message', async function({ uuid, commandData, userEnvironment }: Arguments) {
   const unixWeek = Math.floor(Date.now() / (1000 * 60 * 60 * 24 * 7));
-
-  if (userNetwork !== undefined) {
-    commandData.network = await getCanonicalNetworkName(userNetwork);
-  }
 
   // Initialize Firebase and anonymously authenticate
   const app = firebase.initializeApp(FIREBASE_CONFIG);

--- a/packages/cli/src/telemetry/send-to-firebase.ts
+++ b/packages/cli/src/telemetry/send-to-firebase.ts
@@ -24,7 +24,7 @@ interface Arguments {
 }
 
 async function getCanonicalNetworkName(network: string) {
-  const config = ConfigManager.cache ?? (await ConfigManager.initNetworkConfiguration({ network }));
+  const config = await ConfigManager.initNetworkConfiguration({ network });
   if (config.network.match(/^dev-/)) {
     return 'development';
   } else {

--- a/packages/cli/test/telemetry.test.js
+++ b/packages/cli/test/telemetry.test.js
@@ -15,7 +15,6 @@ import 'firebase/firestore';
 
 import Telemetry from '../src/telemetry';
 import ProjectFile from '../src/models/files/ProjectFile';
-import ConfigManager from '../src/models/config/ConfigManager';
 
 import * as prompt from '../src/prompts/prompt';
 
@@ -128,35 +127,29 @@ describe('telemetry', function() {
                 stringField: 'foo',
                 numberField: 3,
                 objectField: { stringField: 'foo', arrayField: [1, 2, 3] },
+                network: 'development',
               };
             });
 
             context('when a non-development network is specified', function() {
-              it('conceals all options recursively except for the command name', async function() {
+              it('conceals all options recursively except for the network name', async function() {
                 await Telemetry.report('create', this.commandData, true);
                 const [, commandData] = this.sendToFirebase.getCall(0).args;
 
                 commandData.name.should.eq('create');
+                commandData.network.should.eq('development');
                 shouldConcealOptions(commandData);
               });
             });
 
             context('when a dev network is specified', function() {
               it('changes the network name to development', async function() {
-                const network = 'dev-209384093';
-
-                // sendToFirebase reads the network name from here.
-                const oldConfigValue = ConfigManager.cache;
-                ConfigManager.cache = { network };
-
-                await Telemetry.report('create', { network: 'development', ...this.commandData }, true);
-                const [, commandData, , userNetwork] = this.sendToFirebase.getCall(0).args;
+                await Telemetry.report('create', { network: 'dev-209384093', ...this.commandData }, true);
+                const [, commandData] = this.sendToFirebase.getCall(0).args;
 
                 commandData.name.should.eq('create');
-                userNetwork.should.eq('development');
+                commandData.network.should.eq('development');
                 shouldConcealOptions(commandData);
-
-                ConfigManager.cache = oldConfigValue;
               });
             });
 


### PR DESCRIPTION
The recent #1393 introduced some changes to `ZWeb3` initialization that made evident an issue with the deploy command: `ZWeb3` was being implicitly accessed too early by using methods in `ContractManager`. Too early means before the it had been initialized properly.

To solve this I added an optional post-processing step to the spec for every parameter, so once we have gathered all the required parameters, we use this step to initialize the config. Now that this is initialized at this time, I've also reverted the changes I had had to introduce to telemetry (to work around some of the config information not being available at the time the telemetry report was produced).