### PR TITLE
Rename postprocessing to after in commands spec

### DIFF
--- a/packages/cli/src/commands/deploy/spec.ts
+++ b/packages/cli/src/commands/deploy/spec.ts
@@ -116,7 +116,7 @@ export const options: Option[] = [
   {
     format: '-f, --from <address>',
     description: 'sender for the contract creation transaction',
-    async postprocess(params) {
+    async after(params) {
       // Once we have all required params (network, timeout, from) we initialize the config.
       if (process.env.NODE_ENV !== 'test') {
         const { default: ConfigManager } = await import('../../models/config/ConfigManager');

--- a/packages/cli/src/register-command.ts
+++ b/packages/cli/src/register-command.ts
@@ -27,13 +27,13 @@ type Param = ParamSimple | ParamVariadic;
 interface ParamSimple {
   variadic?: false;
   details?: (params: object) => Promise<ParamDetails | undefined>;
-  postprocess?: (params: object) => Promise<void>;
+  after?: (params: object) => Promise<void>;
 }
 
 interface ParamVariadic {
   variadic: true;
   details?: (params: object) => Promise<ParamDetails[]>;
-  postprocess?: (params: object) => Promise<void>;
+  after?: (params: object) => Promise<void>;
 }
 
 export type Arg = Param & { name: string };
@@ -112,7 +112,7 @@ async function promptOrValidateAll(cmd: Command, spec: CommandSpec, params: Comm
     } else {
       await promptOrValidateSimple(name, param, params);
     }
-    await param.postprocess?.(params);
+    await param.after?.(params);
   }
 }
 

--- a/packages/cli/test/telemetry.test.js
+++ b/packages/cli/test/telemetry.test.js
@@ -132,7 +132,7 @@ describe('telemetry', function() {
             });
 
             context('when a non-development network is specified', function() {
-              it('conceals all options recursively except for the network name', async function() {
+              it('conceals all options recursively except for the command and network name', async function() {
                 await Telemetry.report('create', this.commandData, true);
                 const [, commandData] = this.sendToFirebase.getCall(0).args;
 


### PR DESCRIPTION
Sorry, I didn't like the name `postprocess`