### PR TITLE
Move docgen to dev dependency

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -64,7 +64,6 @@
     "glob": "^7.1.3",
     "lodash": "^4.17.15",
     "semver": "^5.5.1",
-    "solidity-docgen": "^0.3.5",
     "spinnies": "^0.4.2",
     "truffle-flattener": "^1.4.0",
     "web3": "1.2.2",
@@ -94,6 +93,7 @@
     "prettier": "^1.19.1",
     "sinon": "^6.1.4",
     "sinon-chai": "^3.3.0",
+    "solidity-docgen": "^0.3.5",
     "tmp": "^0.0.33",
     "ts-node": "^8.5.4",
     "typescript": "^3.7.3"


### PR DESCRIPTION
Porting https://github.com/OpenZeppelin/openzeppelin-sdk/pull/1428 to `master`.