### PR TITLE
Fix error in verify spec

### DIFF
--- a/packages/cli/src/commands/verify/action.ts
+++ b/packages/cli/src/commands/verify/action.ts
@@ -2,8 +2,6 @@ import NetworkController from '../../models/network/NetworkController';
 import { Options, Args } from './spec';
 import ConfigManager from '../../models/config/ConfigManager';
 
-import ProjectFile from '../../models/files/ProjectFile';
-
 export async function action(params: Options & Args & { dontExitProcess: boolean }): Promise<void> {
   if (process.env.NODE_ENV !== 'test') {
     const { network } = await ConfigManager.initNetworkConfiguration(params);

--- a/packages/cli/src/commands/verify/spec.ts
+++ b/packages/cli/src/commands/verify/spec.ts
@@ -62,13 +62,6 @@ export const options: Option[] = [
         };
       }
     },
-    async after(params) {
-      if (process.env.NODE_ENV !== 'test') {
-        const { default: ConfigManager } = await import('../../models/config/ConfigManager');
-        const config = await ConfigManager.initNetworkConfiguration(params);
-        Object.assign(params, config);
-      }
-    },
   },
   {
     format: '-o, --optimizer <enabled>',


### PR DESCRIPTION
Fixes an error introduced in #1443. Commit https://github.com/OpenZeppelin/openzeppelin-sdk/pull/1443/commits/575c4b06986937076f1d6d2e806b31a49343fd5b should have removed some lines but didn't.

Also removes an unused import.

The pull request is for CI. Will merge without review.