### PR TITLE
Add nicer error message to catch verify of regular instances

### DIFF
--- a/packages/cli/src/commands/verify/action.ts
+++ b/packages/cli/src/commands/verify/action.ts
@@ -16,7 +16,7 @@ export async function action(params: Options & Args & { dontExitProcess: boolean
 
   if (!controller.isContractDeployed(params.contract)) {
     throw new Error(
-      `Contract '${params.contract}' has no proxies in network '${userNetworkName}'.\n\nVerification of regular instances is not yet supported.`,
+      `Contract '${params.contract}' is not deployed to '${userNetworkName}'.\n\nVerification of regular instances is not yet supported.`,
     );
   }
 

--- a/packages/cli/src/commands/verify/action.ts
+++ b/packages/cli/src/commands/verify/action.ts
@@ -5,12 +5,20 @@ import ConfigManager from '../../models/config/ConfigManager';
 import ProjectFile from '../../models/files/ProjectFile';
 
 export async function action(params: Options & Args & { dontExitProcess: boolean }): Promise<void> {
+  const userNetworkName = params.network;
+
   if (process.env.NODE_ENV !== 'test') {
     const { network } = await ConfigManager.initNetworkConfiguration(params);
     Object.assign(params, { network });
   }
 
   const controller = new NetworkController(params.network, params.txParams, params.networkFile);
+
+  if (!controller.isContractDeployed(params.contract)) {
+    throw new Error(
+      `Contract '${params.contract}' has no proxies in network '${userNetworkName}'.\n\nVerification of regular instances is not yet supported.`,
+    );
+  }
 
   controller.checkLocalContractDeployed(params.contract, true);
 


### PR DESCRIPTION
`controller.isContractDeployed` checks if a contract is deployed as an _implementation_ for a proxy. If a contract isn't deployed, there is already an error produced by `checkLocalContractDeployed`. I added a different error which contains a warning about regular instances not being supported in verify yet.