### PR TITLE
Integration test for regular deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,13 @@ jobs:
           workspace: examples/first-project
           run-yarn: true
 
+  integration-cli-regular-deploys:
+    <<: *defaults
+    steps:
+      - test:
+          workspace: tests/regular-deploys
+          run-yarn: true
+
   integration-cli-geth: &integration
     <<: *defaults
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,13 +123,6 @@ jobs:
           workspace: examples/first-project
           run-yarn: true
 
-  integration-cli-regular-deploys:
-    <<: *defaults
-    steps:
-      - test:
-          workspace: tests/regular-deploys
-          run-yarn: true
-
   integration-cli-geth: &integration
     <<: *defaults
     docker:
@@ -156,6 +149,13 @@ jobs:
     steps:
       - test:
           workspace: tests/kits/test
+          run-yarn: true
+
+  integration-cli-regular-deploys:
+    <<: *integration
+    steps:
+      - test:
+          workspace: tests/regular-deploys
           run-yarn: true
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,3 +181,5 @@ workflows:
           requires: [test-lib, test-cli]
       - integration-cli-kits:
           requires: [test-lib, test-cli]
+      - integration-cli-regular-deploys:
+          requires: [test-lib, test-cli]

--- a/examples/upgrades-library/package.json
+++ b/examples/upgrades-library/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@openzeppelin/cli": "2.7.0",
-    "@openzeppelin/test-environment": "^0.1.1",
+    "@openzeppelin/test-environment": "^0.1.2",
     "chai": "^4.1.2",
     "mocha": "^6.2.2"
   }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "tests/cli/workdir",
     "tests/kits/test",
     "tests/kits/workdir",
-    "tests/mocks/*"
+    "tests/mocks/*",
+    "tests/regular-deploys"
   ],
   "nohoist": [
     "**/mock-stdlib"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -58,7 +58,7 @@
   "homepage": "https://github.com/OpenZeppelin/openzeppelin-sdk/tree/master/packages/cli#readme",
   "dependencies": {
     "@openzeppelin/fuzzy-solidity-import-parser": "^0.1.2",
-    "@openzeppelin/test-environment": "^0.1.0",
+    "@openzeppelin/test-environment": "^0.1.2",
     "@openzeppelin/upgrades": "2.7.0",
     "@types/fs-extra": "^7.0.0",
     "@types/npm": "^2.0.29",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -73,7 +73,7 @@
     "web3-utils": "1.2.2"
   },
   "devDependencies": {
-    "@openzeppelin/test-environment": "^0.1.0",
+    "@openzeppelin/test-environment": "^0.1.2",
     "@openzeppelin/test-helpers": "^0.5.4",
     "@types/lodash": "^4.14.149",
     "@types/mocha": "^5.2.5",

--- a/tests/regular-deploys/.gitignore
+++ b/tests/regular-deploys/.gitignore
@@ -1,2 +1,2 @@
 /.openzeppelin
-/networks.js
+/extra-networks.json

--- a/tests/regular-deploys/.gitignore
+++ b/tests/regular-deploys/.gitignore
@@ -1,0 +1,2 @@
+/.openzeppelin
+/networks.js

--- a/tests/regular-deploys/.openzeppelin/project.json
+++ b/tests/regular-deploys/.openzeppelin/project.json
@@ -1,0 +1,23 @@
+{
+  "manifestVersion": "2.2",
+  "contracts": {},
+  "dependencies": {},
+  "name": "regular-deploys",
+  "version": "0.1.0",
+  "compiler": {
+    "compilerSettings": {
+      "optimizer": {
+        "enabled": false,
+        "runs": "200"
+      }
+    },
+    "typechain": {
+      "enabled": false
+    },
+    "manager": "openzeppelin",
+    "solcVersion": "0.5.16",
+    "artifactsDir": "build/contracts",
+    "contractsDir": "contracts"
+  },
+  "telemetryOptIn": false
+}

--- a/tests/regular-deploys/contracts/Demo.sol
+++ b/tests/regular-deploys/contracts/Demo.sol
@@ -1,0 +1,5 @@
+pragma solidity ^0.5.0;
+
+contract Demo {
+  uint public answer = 42;
+}

--- a/tests/regular-deploys/networks.js
+++ b/tests/regular-deploys/networks.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+
+const extra = fs.existsSync('extra-networks.json')
+  ? JSON.parse(fs.readFileSync('extra-networks.json'))
+  : {};
+
+module.exports = {
+  networks: {
+    'geth-dev': {
+      url: 'http://localhost:8545',
+      networkId: '9955',
+      gasPrice: 1e9,
+    },
+    ...extra
+  },
+};

--- a/tests/regular-deploys/package.json
+++ b/tests/regular-deploys/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "regular-deploys",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node test.js"
+  },
+  "license": "MIT",
+  "private": true,
+  "dependencies": {
+    "@openzeppelin/cli": "2.7.0",
+    "@openzeppelin/test-environment": "^0.1.2"
+  }
+}

--- a/tests/regular-deploys/test.js
+++ b/tests/regular-deploys/test.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const proc = require('child_process');
+const assert = require('assert');
+const { promisify } = require('util');
+
+const writeFile = promisify(fs.writeFile);
+const exec = promisify(proc.exec);
+
+const { provider } = require('@openzeppelin/test-environment');
+
+async function main() {
+  await provider.queue.onIdle();
+
+  const url = provider.wrappedProvider.host;
+  const config = { networks: { dev: { url } } };
+
+  await writeFile('networks.js', `module.exports = ${JSON.stringify(config)};\n`);
+
+  const deploy = await exec('oz deploy -n dev -k regular Demo');
+  const address = deploy.stdout.trim();
+
+  const call = await exec(`oz call -n dev --to "${address}" --method answer`)
+  assert.strictEqual(call.stdout, '42\n');
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exitCode = 1;
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1013,6 +1013,15 @@
     fs-extra "^8.1.0"
     try-require "^1.2.1"
 
+"@openzeppelin/contract-loader@^0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contract-loader/-/contract-loader-0.6.1.tgz#fa0fbddf78d1ec8e6c9bbe25d8e5d646274541f9"
+  integrity sha512-vYNapuK6THq5ueOReFkMfW4Ajk4gZ8jdf1AeoFUyD/U4gQyIedROU0/GB9J93mQ1hb8wVrxiWjGq6Ou3OVbjVg==
+  dependencies:
+    find-up "^4.1.0"
+    fs-extra "^8.1.0"
+    try-require "^1.2.1"
+
 "@openzeppelin/fuzzy-solidity-import-parser@^0.1.2":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@openzeppelin/fuzzy-solidity-import-parser/-/fuzzy-solidity-import-parser-0.1.2.tgz#3b9f524d6028ca73df60474a313e0295e5610c51"
@@ -1041,6 +1050,23 @@
   integrity sha512-Ce79b4f+NUHYD2+vGnO8eXPHie3FDGRMWettIHfP/C/JMnfoSM8FJlqyGy3A0TMC0xDI2kbTQ/ofRotR/Un2yA==
   dependencies:
     "@openzeppelin/contract-loader" "^0.5.0"
+    "@truffle/contract" "^4.0.38"
+    ansi-colors "^4.1.1"
+    ethereumjs-wallet "^0.6.3"
+    find-up "^4.1.0"
+    ganache-core "^2.8.0"
+    lodash.merge "^4.6.2"
+    p-queue "^6.2.0"
+    semver "^6.3.0"
+    try-require "^1.2.1"
+    web3 "1.2.2"
+
+"@openzeppelin/test-environment@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/test-environment/-/test-environment-0.1.2.tgz#62fa8d1b00d45a8c7a0e7de20e230abef3fb1178"
+  integrity sha512-dgtpN6voS1UmTvV3qwymZDiVRhRDxI+Fl9UQciTFvvpgsSSPL4jVwaKoYSCO/IMcYynzQJvrQtw6LT5wI2Ayjg==
+  dependencies:
+    "@openzeppelin/contract-loader" "^0.6.1"
     "@truffle/contract" "^4.0.38"
     ansi-colors "^4.1.1"
     ethereumjs-wallet "^0.6.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1004,15 +1004,6 @@
     fs-extra "^8.1.0"
     try-require "^1.2.1"
 
-"@openzeppelin/contract-loader@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contract-loader/-/contract-loader-0.5.0.tgz#f82aeb3a2cecf3f16d97ba2989b2541ca6d045bd"
-  integrity sha512-RAUKHIaX7fPJ1snKPReFntW0WjeuDBXw3SFeJCG8uoBmbqkBK4ukXD51Fa8kRsd/aQGx1svTCTtiaFP0fg4XNw==
-  dependencies:
-    find-up "^4.1.0"
-    fs-extra "^8.1.0"
-    try-require "^1.2.1"
-
 "@openzeppelin/contract-loader@^0.6.1":
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contract-loader/-/contract-loader-0.6.1.tgz#fa0fbddf78d1ec8e6c9bbe25d8e5d646274541f9"
@@ -1026,40 +1017,6 @@
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@openzeppelin/fuzzy-solidity-import-parser/-/fuzzy-solidity-import-parser-0.1.2.tgz#3b9f524d6028ca73df60474a313e0295e5610c51"
   integrity sha512-leqEwfs8GlrPDrVcVc8Hv6LJ62ZzR0RgjwQNCkpT6H5jW9RB8YdR0a3inHoricSvw+sKI1b1hOqsCtPPZNnhng==
-
-"@openzeppelin/test-environment@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/test-environment/-/test-environment-0.1.0.tgz#f43b9e8ca526cc3d2ff1ac855033646e72b1acfe"
-  integrity sha512-6Nic+mTkJTqK/kbc/wRkmNsOuKX682iEOE6IuzqQrFbPwY6MpHdFgSExKAk1YL9G8UWovpyQPSp/t6e6annzfg==
-  dependencies:
-    "@openzeppelin/contract-loader" "^0.5.0"
-    "@truffle/contract" "^4.0.38"
-    ansi-colors "^4.1.1"
-    ethereumjs-wallet "^0.6.3"
-    find-up "^4.1.0"
-    ganache-core "^2.8.0"
-    lodash.merge "^4.6.2"
-    p-queue "^6.2.0"
-    semver "^6.3.0"
-    try-require "^1.2.1"
-    web3 "1.2.2"
-
-"@openzeppelin/test-environment@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/test-environment/-/test-environment-0.1.1.tgz#e733d6ce1efbc8079ce92d9371ba5eeb07257dee"
-  integrity sha512-Ce79b4f+NUHYD2+vGnO8eXPHie3FDGRMWettIHfP/C/JMnfoSM8FJlqyGy3A0TMC0xDI2kbTQ/ofRotR/Un2yA==
-  dependencies:
-    "@openzeppelin/contract-loader" "^0.5.0"
-    "@truffle/contract" "^4.0.38"
-    ansi-colors "^4.1.1"
-    ethereumjs-wallet "^0.6.3"
-    find-up "^4.1.0"
-    ganache-core "^2.8.0"
-    lodash.merge "^4.6.2"
-    p-queue "^6.2.0"
-    semver "^6.3.0"
-    try-require "^1.2.1"
-    web3 "1.2.2"
 
 "@openzeppelin/test-environment@^0.1.2":
   version "0.1.2"


### PR DESCRIPTION
Adds an integration test that deploys a non-upgradeable instance using `deploy` and calls a function on it to verify the deploy went fine.