### PR TITLE
Change TypeScript compilation target to es2017

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "disableSizeLimit": true,
     "module": "commonjs",
     "moduleResolution": "Node",
-    "target": "es6",
+    "target": "es2017",
     "allowJs": true,
     "checkJs": false,
     "strict": false,


### PR DESCRIPTION
Fixes https://github.com/OpenZeppelin/openzeppelin-sdk/issues/1405.

The size of the compiled JavaScript was reduced by about 10%.