### PR TITLE
Fix network bug in init

### DIFF
--- a/packages/cli/src/commands/deploy/action.ts
+++ b/packages/cli/src/commands/deploy/action.ts
@@ -3,7 +3,6 @@ import { getConstructorInputs } from '@openzeppelin/upgrades';
 import Session from '../../models/network/Session';
 import { compile } from '../../models/compiler/Compiler';
 import { fromContractFullName } from '../../utils/naming';
-import ConfigManager from '../../models/config/ConfigManager';
 import NetworkController from '../../models/network/NetworkController';
 import stdout from '../../utils/stdout';
 import { parseMultipleArgs } from '../../utils/input';

--- a/packages/cli/src/commands/verify/action.ts
+++ b/packages/cli/src/commands/verify/action.ts
@@ -1,14 +1,8 @@
 import NetworkController from '../../models/network/NetworkController';
 import { Options, Args } from './spec';
-import ConfigManager from '../../models/config/ConfigManager';
 
 export async function action(params: Options & Args & { dontExitProcess: boolean }): Promise<void> {
-  const userNetworkName = params.network;
-
-  if (process.env.NODE_ENV !== 'test') {
-    const { network } = await ConfigManager.initNetworkConfiguration(params);
-    Object.assign(params, { network });
-  }
+  const { userNetworkName } = params;
 
   const controller = new NetworkController(params.network, params.txParams, params.networkFile);
 

--- a/packages/cli/src/commands/verify/spec.ts
+++ b/packages/cli/src/commands/verify/spec.ts
@@ -23,6 +23,8 @@ interface OtherOptions {
   // The following are not available as CLI flags, and they are only used in tests.
   networkFile?: NetworkFile;
   txParams?: TxParams;
+  // This is not a CLI flag. It is set right after the network option is obtained.
+  userNetworkName?: string;
 }
 
 export type Options = OptimizerOptions & RemoteOptions & OtherOptions;
@@ -62,6 +64,14 @@ export const options: Option[] = [
         };
       }
     },
+    async after(params: Options) {
+      if (process.env.NODE_ENV !== 'test') {
+        const { default: ConfigManager } = await import('../../models/config/ConfigManager');
+        const { network } = await ConfigManager.initNetworkConfiguration(params);
+        const userNetworkName = params.network;
+        Object.assign(params, { network, userNetworkName });
+      }
+    }
   },
   {
     format: '-o, --optimizer <enabled>',

--- a/packages/cli/src/commands/verify/spec.ts
+++ b/packages/cli/src/commands/verify/spec.ts
@@ -71,7 +71,7 @@ export const options: Option[] = [
         const userNetworkName = params.network;
         Object.assign(params, { network, userNetworkName });
       }
-    }
+    },
   },
   {
     format: '-o, --optimizer <enabled>',

--- a/packages/cli/src/telemetry/index.ts
+++ b/packages/cli/src/telemetry/index.ts
@@ -38,9 +38,8 @@ export default {
     if (telemetryOptions === undefined || !telemetryOptions.optIn) return;
 
     // normalize network name
-    const { ZWeb3 } = await import('@openzeppelin/upgrades');
-    let network = await ZWeb3.getNetworkName();
-    if (network.match(/dev-/)) {
+    let network = params.network as string | undefined;
+    if (network !== undefined && network.match(/dev-/)) {
       network = 'development';
     }
 


### PR DESCRIPTION
Fixes #1464 

This bug was caused by a call to the Web3 network in `Telemetry.report`.

https://github.com/OpenZeppelin/openzeppelin-sdk/blob/08fdbaa4f9857f08dedeaa15900035156e1a60e0/packages/cli/src/telemetry/index.ts#L42

The reason this was there was that, in the new command framework, `Telemetry.report` is called before a command's action runs. Depending on the command spec, the network name may not be canonicalized yet. I've now changed the specs for `deploy` and `verify` to make sure the canonical name is already present once it reaches telemetry. (This was actually already done in `deploy`. I don't know why this code in telemetry had remained.)

We shouldn't rely on the spec to be coded this way though, and we need to introduce an abstraction here that would avoid the mistake of sending the user-provided network name to telemetry. There's a lot of issues around network initialization. We should give it some good thought and come up with a good solution!