### PR TITLE
Add deprecation warning to create

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -45,6 +45,15 @@ export async function createAction(contractFullName: string, options: any): Prom
     Loggy.noSpin.warn(__filename, 'action', 'create-minimal-proxy', 'Minimal proxy support is still experimental.');
   }
 
+  if (!options.noDeprecationWarning) {
+    Loggy.noSpin.warn(
+      __filename,
+      'action',
+      'create-deprecation',
+      'The create command is deprecated. Use deploy instead.',
+    );
+  }
+
   const { skipCompile } = options;
   if (!skipCompile) await compile();
 

--- a/packages/cli/src/commands/deploy/action.ts
+++ b/packages/cli/src/commands/deploy/action.ts
@@ -60,6 +60,9 @@ export async function action(params: Options & Args): Promise<void> {
 }
 
 async function runCreate(params: Options & Args): Promise<void> {
+  // The syntax params['key'] is used to circumvent the type checker.
+  // This hack is temporary and should be removed once we remove the create command.
+
   if (params.arguments.length > 0) {
     // Translate arguments to syntax expected by create.
     params['args'] = params.arguments.join(',');
@@ -70,6 +73,7 @@ async function runCreate(params: Options & Args): Promise<void> {
   }
 
   params.skipCompile = true;
+  params['noDeprecationWarning'] = true;
 
   await createAction(params.contract, params);
 }


### PR DESCRIPTION
We are deprecating `create` in favor of `deploy`.