### PR TITLE
Disable automatic help text in new command framework

### DIFF
--- a/packages/cli/src/register-command.ts
+++ b/packages/cli/src/register-command.ts
@@ -64,7 +64,7 @@ export function register(program: Command, spec: CommandSpec, getAction: () => P
   const signature = generateSignature(spec.name, spec.args);
 
   const command = program
-    .command(signature)
+    .command(signature, undefined, { noHelp: true })
     .description(spec.description)
     .action(async (...actionArgs: unknown[]) => {
       const { preAction, action }: Action = await getAction();


### PR DESCRIPTION
We are using custom code for the help text (are we using commander for anything at all? :stuck_out_tongue:) and forgot to disable the default in the new command framework. It looked like this:

![image](https://user-images.githubusercontent.com/481465/75385932-85805780-58bf-11ea-92fb-2ecb6b5d65c9.png)

The same commands are already present later in the output.