### PR TITLE
Add declaration map configuration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "strict": false,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "lib": ["es2017"]
+    "lib": ["es2017"],
+    "declarationMap": true
   },
   "exclude": ["**/node_modules/*", "**/*.spec.ts"]
 }


### PR DESCRIPTION
Enabling declaration maps in TypeScript makes "jump to definition" go to the source code rather than the `d.ts` file.