### PR TITLE
Add hint to use oz upgrade after upgradeable deployment

### DIFF
--- a/packages/cli/src/commands/deploy/action.ts
+++ b/packages/cli/src/commands/deploy/action.ts
@@ -56,7 +56,7 @@ export async function action(params: Options & Args): Promise<void> {
     const instance = await controller.createInstance(packageName, contractName, args);
 
     if (params.kind === 'upgradeable') {
-      Loggy.noSpin.info(__filename, 'deploy', 'deploy-hint', `Upgrade this instance using 'oz upgrade'`);
+      Loggy.noSpin(__filename, 'deploy', 'deploy-hint', `Upgrade this instance using 'oz upgrade'`);
     }
 
     stdout(instance.address);

--- a/packages/cli/src/commands/deploy/action.ts
+++ b/packages/cli/src/commands/deploy/action.ts
@@ -56,7 +56,7 @@ export async function action(params: Options & Args): Promise<void> {
     const instance = await controller.createInstance(packageName, contractName, args);
 
     if (params.kind === 'upgradeable') {
-      Loggy.noSpin(__filename, 'deploy', 'deploy-hint', `Upgrade this instance using 'oz upgrade'`);
+      Loggy.noSpin(__filename, 'deploy', 'deploy-hint', `To upgrade this instance run 'oz upgrade'`);
     }
 
     stdout(instance.address);

--- a/packages/cli/src/commands/deploy/action.ts
+++ b/packages/cli/src/commands/deploy/action.ts
@@ -7,6 +7,7 @@ import NetworkController from '../../models/network/NetworkController';
 import stdout from '../../utils/stdout';
 import { parseMultipleArgs } from '../../utils/input';
 import { createAction } from '../create';
+import { Loggy } from '@openzeppelin/upgrades';
 
 import { Options, Args } from './spec';
 
@@ -53,6 +54,11 @@ export async function action(params: Options & Args): Promise<void> {
 
   try {
     const instance = await controller.createInstance(packageName, contractAlias, args);
+
+    if (params.kind === 'upgradeable') {
+      Loggy.noSpin.info(__filename, 'deploy', 'deploy-hint', `Upgrade this instance using 'oz upgrade'`);
+    }
+
     stdout(instance.address);
   } finally {
     controller.writeNetworkPackageIfNeeded();

--- a/packages/cli/src/scripts/create.ts
+++ b/packages/cli/src/scripts/create.ts
@@ -35,7 +35,7 @@ export default async function createProxy({
       kind,
     );
 
-    Loggy.noSpin(__filename, 'deploy', 'deploy-hint', `Upgrade this instance using 'oz upgrade'`);
+    Loggy.noSpin(__filename, 'deploy', 'deploy-hint', `To upgrade this instance run 'oz upgrade'`);
 
     stdout(proxy.address);
 

--- a/packages/cli/src/scripts/create.ts
+++ b/packages/cli/src/scripts/create.ts
@@ -1,7 +1,7 @@
 import stdout from '../utils/stdout';
 import NetworkController from '../models/network/NetworkController';
 import { CreateParams, ProxyType } from './interfaces';
-import { Contract } from '@openzeppelin/upgrades';
+import { Contract, Loggy } from '@openzeppelin/upgrades';
 import { validateSalt } from '../utils/input';
 
 export default async function createProxy({
@@ -34,6 +34,9 @@ export default async function createProxy({
       signature,
       kind,
     );
+
+    Loggy.noSpin.info(__filename, 'deploy', 'deploy-hint', `Upgrade this instance using 'oz upgrade'`);
+
     stdout(proxy.address);
 
     return proxy;

--- a/packages/cli/src/scripts/create.ts
+++ b/packages/cli/src/scripts/create.ts
@@ -35,7 +35,7 @@ export default async function createProxy({
       kind,
     );
 
-    Loggy.noSpin.info(__filename, 'deploy', 'deploy-hint', `Upgrade this instance using 'oz upgrade'`);
+    Loggy.noSpin(__filename, 'deploy', 'deploy-hint', `Upgrade this instance using 'oz upgrade'`);
 
     stdout(proxy.address);
 


### PR DESCRIPTION
Fixes https://github.com/OpenZeppelin/openzeppelin-sdk/issues/1410.

I'm not sure I love the way this looks, honestly. But we don't have another way to show this kind of notice right now. We can improve it in the future.

![image](https://user-images.githubusercontent.com/481465/75727097-de3a6080-5cc2-11ea-8772-20ff18d14f3a.png)
