### PR TITLE
Add extra warning in verify when a regular instance is found

### DIFF
--- a/packages/cli/src/models/network/NetworkController.ts
+++ b/packages/cli/src/models/network/NetworkController.ts
@@ -505,6 +505,16 @@ export default class NetworkController {
     const { compilerVersion, sourcePath } = this.localController.getContractSourcePath(contractName);
     const contractSource = await flattenSourceCode([sourcePath]);
     const contractAddress = this.networkFile.contracts[contractName].address;
+
+    if (this.networkFile.getProxies({ contractName, kind: ProxyType.NonProxy }).length > 0) {
+      Loggy.noSpin(
+        __filename,
+        'verifyAndPublishContract',
+        'verify-and-publish-nonproxy',
+        `A regular instance of ${contractName} was found. Verification of regular instances is not yet supported.`,
+      );
+    }
+
     await Verifier.verifyAndPublish(remote, {
       contractName,
       compilerVersion,


### PR DESCRIPTION
Fixes https://github.com/OpenZeppelin/openzeppelin-sdk/issues/1475

For cases when there is both upgradeable and regular instances of the same contract, this will print a warning in `verify` saying that verifying regular instances doesn't work yet.