### PR TITLE
Change documentation and messages to use oz deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ And initialize the OpenZeppelin SDK project:
 openzeppelin init my-project
 ```
 
-Now it is possible to use `openzeppelin create` to create instances for these contracts that 
+Now it is possible to use `openzeppelin deploy` to create instances for these contracts that 
 later can be upgraded, and many more things.
 
 Run `openzeppelin --help` for more details about thes and all the other functions of the

--- a/examples/first-project/README.md
+++ b/examples/first-project/README.md
@@ -5,5 +5,5 @@ This is a sample project with a single contract for getting started with the Ope
 To run it on your machine:
 - Install dependencies with `npm install`
 - Start a ganache instance with `npx ganache-cli -p 8545 -d`
-- Create a new `Counter` contract instance with `npx openzeppelin create Counter --network development`
+- Create a new `Counter` contract instance with `npx openzeppelin deploy Counter --network development`
 - Run the main script with `node src/index.js`

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -44,7 +44,7 @@ openzeppelin init my-project
 
 Now it is possible to add contracts to the project with the `openzeppelin add` command,
 push these contracts to a blockchain network with `openzeppelin push`, use
-`openzeppelin create` to create instances for these contracts that later can be
+`openzeppelin deploy` to create instances for these contracts that later can be
 upgraded, and many more things.
 
 Run `openzeppelin --help` for more details about this and all the other functions of

--- a/packages/cli/docs/modules/ROOT/pages/compiling.adoc
+++ b/packages/cli/docs/modules/ROOT/pages/compiling.adoc
@@ -6,7 +6,7 @@ This guide covers how compiling works, its different options, and the output for
 
 == Running the Compiler
 
-Most CLI commands, like `oz create` or `oz upgrade`, will automatically compile your projects smart contracts when required, so you don't need to worry about doing this yourself.
+Most CLI commands, like `oz deploy` or `oz upgrade`, will automatically compile your projects smart contracts when required, so you don't need to worry about doing this yourself.
 
 However, you can also just run the compilation by itself, using the xref:commands.adoc#compile[`oz compile`] command:
 

--- a/packages/cli/docs/modules/ROOT/pages/contracts-architecture.adoc
+++ b/packages/cli/docs/modules/ROOT/pages/contracts-architecture.adoc
@@ -18,7 +18,7 @@ xref:upgrades::api.adoc#ProxyAdmin[`ProxyAdmin`] is a central admin for all xref
 
 As an admin of all proxy contracts it is in charge of upgrading them, as well as transferring their ownership to another admin. This contract is used to complement the xref:upgrades::proxies.adoc#transparent-proxies-and-function-clashes[Transparent Proxy Pattern], which prevents an admin from accidentally triggering a proxy management function when interacting with their instances. `ProxyAdmin` is owned by its deployer (the project owner), and exposes its administrative interface to this account.
 
-A `ProxyAdmin` is only deployed when you run an `oz create` (or `oz create2`) command for the first time. You can force the CLI to deploy one by running `oz push --deploy-proxy-admin`.
+A `ProxyAdmin` is only deployed when you run an `oz deploy` (or `oz create2`) command for the first time. You can force the CLI to deploy one by running `oz push --deploy-proxy-admin`.
 
 You can read its source code https://github.com/OpenZeppelin/openzeppelin-sdk/blob/v2.6.0/packages/lib/contracts/upgradeability/ProxyAdmin.sol[here].
 
@@ -63,7 +63,7 @@ You can find your `ProxyAdmin` contract address in xref:configuration.adoc#netwo
 
 xref:upgrades::api.adoc#ProxyFactory[`ProxyFactory`] is used when creating contracts via the `oz create2` command, as well as when creating minimal proxies. It contains all the necessary methods to deploy a proxy through the `CREATE2` opcode or a minimal non-upgradeable proxy.
 
-This contract is only deployed when you run `openzeppelin create2` or `openzeppelin create --minimal` for the first time. You can force the CLI to deploy it by running `openzeppelin push --deploy-proxy-factory`.
+This contract is only deployed when you run `openzeppelin create2` or `openzeppelin deploy --kind minimal` for the first time. You can force the CLI to deploy it by running `openzeppelin push --deploy-proxy-factory`.
 
 You can read its source code https://github.com/OpenZeppelin/openzeppelin-sdk/blob/v2.6.0/packages/lib/contracts/upgradeability/ProxyFactory.sol[here].
 

--- a/packages/cli/docs/modules/ROOT/pages/dependencies.adoc
+++ b/packages/cli/docs/modules/ROOT/pages/dependencies.adoc
@@ -53,9 +53,10 @@ NOTE: The unlocked accounts and transaction hashes may differ from the ones show
 
 [source,console]
 ----
-$ npx oz create
-? Pick a contract to instantiate: @openzeppelin/contracts-ethereum-package/StandaloneERC20
+$ npx oz deploy
+? Choose the kind of deployment: upgradeable
 ? Pick a network: development
+? Pick a contract to deploy: @openzeppelin/contracts-ethereum-package/StandaloneERC20
 ✓ Deploying @openzeppelin/contracts-ethereum-package dependency to network
 ? Call a function to initialize the instance after creating it?: Yes
 ? Select which function: * initialize(name: string, symbol: string, decimals: uint8, initialSupply: uint256, initialHolder: address, minters: address[], pausers: address[])
@@ -87,7 +88,7 @@ Great! We can now write an exchange contract and connect it to this token when w
 [[writing-the-exchange-contract]]
 == Writing the Exchange Contract
 
-In order to transfer an amount of tokens every time it receives ETH, our exchange contract will need to store the token contract address and the exchange rate in its state. We will set these two values during initialization, when we create the instance with `oz create`.
+In order to transfer an amount of tokens every time it receives ETH, our exchange contract will need to store the token contract address and the exchange rate in its state. We will set these two values during initialization, when we create the instance with `oz deploy`.
 
 Because we're writing upgradeable contracts xref:upgrades::proxies.adoc#the-constructor-caveat[we cannot use Solidity `constructor` s]. Instead, we need to use _initializers_. An initializer is just a regular Solidity function, with an additional check to ensure that it can be called only once.
 
@@ -139,10 +140,11 @@ Let's now create and initialize our new `TokenExchange` contract:
 
 [source,console]
 ----
-$ npx oz create
+$ npx oz deploy
 ✓ Compiled contracts with solc 0.5.9 (commit.e560f70d)
-? Pick a contract to instantiate: TokenExchange
+? Choose the kind of deployment: upgradeable
 ? Pick a network: development
+? Pick a contract to instantiate: TokenExchange
 ✓ Contract TokenExchange deployed
 ? Call a function to initialize the instance after creating it?: Yes
 ? Select which function: initialize(_rate: uint256, _token: address)

--- a/packages/cli/docs/modules/ROOT/pages/deploying-with-create2.adoc
+++ b/packages/cli/docs/modules/ROOT/pages/deploying-with-create2.adoc
@@ -19,7 +19,7 @@ TIP: If you are already familiar with the goals behind `CREATE2`, feel free to <
 
 === `CREATE`
 
-Smart contracts can be created both by other contracts (using https://solidity.readthedocs.io/en/v0.5.15/control-structures.html#creating-contracts-via-new[Solidity's `new` keyword]) and by regular accounts (such as when running xref:commands.adoc#create[`oz create`]). In both cases, the address for the new contract is computed the same way: as a function of the sender's own address and a nonce.
+Smart contracts can be created both by other contracts (using https://solidity.readthedocs.io/en/v0.5.15/control-structures.html#creating-contracts-via-new[Solidity's `new` keyword]) and by regular accounts (such as when running xref:commands.adoc#create[`oz deploy`]). In both cases, the address for the new contract is computed the same way: as a function of the sender's own address and a nonce.
 
 [source,console]
 ----

--- a/packages/cli/docs/modules/ROOT/pages/getting-started.adoc
+++ b/packages/cli/docs/modules/ROOT/pages/getting-started.adoc
@@ -81,14 +81,15 @@ Open a separate terminal and start a new Ganache process:
 $ npx ganache-cli --deterministic
 ----
 
-This will start a new development network using a deterministic set of accounts, instead of random ones. We can now deploy our contract there, running `oz create`, and choosing to deploy the `Counter` contract to the `development` network.
+This will start a new development network using a deterministic set of accounts, instead of random ones. We can now deploy our contract there, running `oz deploy`, and choosing to deploy the `Counter` contract to the `development` network.
 
 [source,console]
 ----
-$ npx oz create
+$ npx oz deploy
 ✓ Compiled contracts with solc 0.5.9 (commit.e560f70d)
-? Pick a contract to instantiate: Counter
+? Choose the kind of deployment: upgradeable
 ? Pick a network: development
+? Pick a contract to instantiate: Counter
 ✓ Added contract Counter
 ✓ Contract Counter deployed
 ? Call a function to initialize the instance after creating it?: No

--- a/packages/cli/docs/modules/ROOT/pages/index.adoc
+++ b/packages/cli/docs/modules/ROOT/pages/index.adoc
@@ -3,7 +3,7 @@
 *Develop, deploy and operate upgradeable smart contract projects*. Support for Ethereum and every other EVM-powered blockchain.
 
 * *Interactive commands*: Send transactions, query balances, and interact with your contracts directly from the command line, using commands like `oz send-tx`, `oz call`, `oz balance`, and `oz transfer`.
-* *Deploy & upgrade your contracts*: You can develop your smart contracts iteratively, speeding up development locally, or squashing bugs in production. Run `oz create` to deploy your contracts, followed by `oz upgrade` any time you want to change their code.
+* *Deploy & upgrade your contracts*: You can develop your smart contracts iteratively, speeding up development locally, or squashing bugs in production. Run `oz deploy` to deploy your contracts, followed by `oz upgrade` any time you want to change their code.
 * *Link Ethereum Packages*: Use code from contracts already deployed to the blockchain directly on your project, saving gas on deployments and managing your dependencies securely, just with an `oz link` command.
 * *Bootstrap your dapp*: Jumpstart your dapp by unpacking one of our starter kits, pre-configured with OpenZeppelin Contracts, React, and Infura. Run `oz unpack` to start!
 
@@ -24,7 +24,7 @@ Below is a short list of the most used commands:
 
   * xref:commands.adoc#init[`oz init`]: initialize your OpenZeppelin project
   * xref:commands.adoc#compile[`oz compile`]: compile all Solidity smart contracts in your project
-  * xref:commands.adoc#create[`oz create`]: deploy an upgradeable smart contract
+  * xref:commands.adoc#deploy[`oz deploy`]: deploy an upgradeable smart contract
   * xref:commands.adoc#send[`oz send-tx`]: send a transaction to a contract and execute a function
   * xref:commands.adoc#call[`oz call`]: read data from the blockchain by calling `view` and `pure` functions
   * xref:commands.adoc#upgrade[`oz upgrade`]: upgrade a deployed contract to a new version without changing the address or state

--- a/packages/cli/docs/modules/ROOT/pages/publishing-ethereum-package.adoc
+++ b/packages/cli/docs/modules/ROOT/pages/publishing-ethereum-package.adoc
@@ -14,7 +14,7 @@ For a refresher on the topics, head to xref:learn::public-staging.adoc[Deploying
 
 == Storing Your Project On-chain
 
-So far, we've mostly limited ourselves to depoying contracts using xref:commands.adoc#create[`oz create`], which creates _upgradeable instances_ by deploying _proxies_ to an existing implementation contract (refer to xref:learn::on-upgrades.adoc#how-upgrades-work[How Upgrades Work] to brush up on this). Here, we will instead deploy just the implementations, so that other people can create new proxies pointing to them.
+So far, we've mostly limited ourselves to depoying contracts using xref:commands.adoc#create[`oz deploy`], which creates _upgradeable instances_ by deploying _proxies_ to an existing implementation contract (refer to xref:learn::on-upgrades.adoc#how-upgrades-work[How Upgrades Work] to brush up on this). Here, we will instead deploy just the implementations, so that other people can create new proxies pointing to them.
 
 To achieve this, we'll use two low-level CLI commands: xref:commands.adoc#add[`oz add`] and xref:commands.adoc#push[`oz push`]. These work simmilarly to `git add` and `git push`: they will register contracts in your project and deploy them to a network.
 

--- a/packages/cli/docs/modules/ROOT/pages/truffle.adoc
+++ b/packages/cli/docs/modules/ROOT/pages/truffle.adoc
@@ -108,11 +108,11 @@ contract Migrations {
 }
 ----
 
-If you now run `openzeppelin create` or any other `openzeppelin` command that depends on compiling first, it will call `truffle compile` under the hood before proceeding with the other operations. The SDK will let you know about this:
+If you now run `openzeppelin deploy` or any other `openzeppelin` command that depends on compiling first, it will call `truffle compile` under the hood before proceeding with the other operations. The SDK will let you know about this:
 
 [source,bash]
 ----
-λ openzeppelin create
+$ openzeppelin deploy
 √ Compiling contracts with Truffle, using settings from truffle.js file
 Truffle output:
 

--- a/packages/cli/src/models/local/LocalController.ts
+++ b/packages/cli/src/models/local/LocalController.ts
@@ -155,7 +155,7 @@ export default class LocalController {
         __filename,
         'linkDependencies',
         'link-dependencies',
-        `${label} linked to the project. Run 'openzeppelin create' to deploy one of its contracts.`,
+        `${label} linked to the project. Run 'openzeppelin deploy' to deploy one of its contracts.`,
       );
     }
   }

--- a/packages/lib/docs/modules/ROOT/pages/creating-upgradeable-from-solidity.adoc
+++ b/packages/lib/docs/modules/ROOT/pages/creating-upgradeable-from-solidity.adoc
@@ -103,12 +103,13 @@ Now that the `App` has been published and `Product` registered inside it, we're 
   ...
 ```
 
-With the `App` address at hand, we can deploy `Factory` using `oz create` as usual:
+With the `App` address at hand, we can deploy `Factory` using `oz deploy` as usual:
 
 [source,console]
 ----
-$ npx oz create
-? Pick a contract to instantiate Factory
+$ npx oz deploy
+? Choose the kind of deployment: upgradeable
+? Pick a contract to instantiate: Factory
 ✓ Added contract Factory
 ✓ Contract Factory deployed
 All contracts have been deployed

--- a/packages/lib/docs/modules/ROOT/pages/proxies.adoc
+++ b/packages/lib/docs/modules/ROOT/pages/proxies.adoc
@@ -138,7 +138,7 @@ This is why when the xref:cli::index.adoc[*OpenZeppelin CLI*] creates a proxy, i
 
 [source,console]
 ----
-$ npx openzeppelin create MyLogicContract --init initialize --args arg1,arg2,arg3
+$ npx openzeppelin deploy MyLogicContract arg1 arg2 arg3
 ----
 
 This command creates a proxy that wraps around `MyLogicContract`, uses `MyLogicContract` as the logic contract, and calls the logic contract's `initialize` function.

--- a/packages/lib/docs/modules/ROOT/pages/writing-upgradeable.adoc
+++ b/packages/lib/docs/modules/ROOT/pages/writing-upgradeable.adoc
@@ -178,7 +178,7 @@ contract MyContract {
 
 When creating a new instance of a contract from your contract's code, these creations are handled directly by Solidity and not by OpenZeppelin Upgrades, which means that *these contracts will not be upgradeable*.
 
-For instance, in the following example, even if `MyContract` is upgradeable (if created via `oz create MyContract`), the `token` contract created is not:
+For instance, in the following example, even if `MyContract` is upgradeable (if created via `oz deploy MyContract`), the `token` contract created is not:
 
 [source,solidity]
 ----
@@ -218,8 +218,8 @@ contract MyContract is Initializable {
 
 [source,console]
 ----
-$ TOKEN=$(npx oz create TokenContract)
-$ npx oz create MyContract --init --args $TOKEN
+$ TOKEN=$(npx oz deploy TokenContract)
+$ npx oz deploy MyContract $TOKEN
 ----
 
 An advanced alternative, if you need to create upgradeable contracts on the fly, is to keep an instance of your OpenZeppelin project's `App` in your contracts. The xref:api.adoc#App[`App`] is a contract that acts as the entrypoint for your OpenZeppelin project, which has references to your logic implementations, and can create new contract instances:


### PR DESCRIPTION
Our documentation and a message printed by the CLI said `oz create` where we should be recommending `oz deploy`. This changes that.

Should be cherry-picked into 2.8.