### PR TITLE
Push contracts selectively during upgrades

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -68,7 +68,7 @@ export async function createAction(contractFullName: string, options: any): Prom
 
   await link.runActionIfNeeded(promptedContractFullName, options);
   await add.runActionIfNeeded(promptedContractFullName, options);
-  await push.runActionIfNeeded(promptedContractFullName, network, {
+  await push.runActionIfNeeded([promptedContractFullName], network, {
     ...options,
     network: promptedNetwork,
   });

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -43,7 +43,7 @@ async function commandActions(options: any): Promise<void> {
 
 async function action(options: any): Promise<void> {
   const {
-    contractAlias,
+    contracts,
     force,
     deployDependencies,
     reset: reupload,
@@ -78,7 +78,7 @@ async function action(options: any): Promise<void> {
     ...promptDeployDependencies,
   };
 
-  if (contractAlias) pushArguments.contractAliases = [contractAlias];
+  if (contracts) pushArguments.contractAliases = contracts;
 
   if (!options.skipTelemetry)
     await Telemetry.report('push', (pushArguments as unknown) as Record<string, unknown>, interactive);
@@ -94,9 +94,9 @@ async function runActionIfRequested(externalOptions: any): Promise<void> {
   return action(options);
 }
 
-async function runActionIfNeeded(contractAlias: string, network: string, options: any): Promise<void> {
+async function runActionIfNeeded(contracts: string[], network: string, options: any): Promise<void> {
   if (!options.interactive) return;
-  await action({ ...options, dontExitProcess: true, skipTelemetry: true, contractAlias });
+  await action({ ...options, dontExitProcess: true, skipTelemetry: true, contracts });
 }
 
 async function promptForDeployDependencies(

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,5 +1,6 @@
-import { pickBy } from 'lodash';
+import { pickBy, uniq } from 'lodash';
 
+import NetworkFile from '../models/files/NetworkFile';
 import push from './push';
 import update from '../scripts/update';
 import { parseContractReference } from '../utils/contract';
@@ -17,6 +18,7 @@ import {
 import promptForMethodParams from '../prompts/method-params';
 import Telemetry from '../telemetry';
 import { ProxyType, UpdateParams } from '../scripts/interfaces';
+import ProjectFile from '../models/files/ProjectFile';
 
 const name = 'upgrade';
 const signature = `${name} [alias-or-address]`;
@@ -48,12 +50,7 @@ async function commandActions(proxyReference: string, options: any): Promise<voi
     network: promptedNetwork,
   });
 
-  await push.runActionIfNeeded(null, network, {
-    ...options,
-    network: promptedNetwork,
-  });
-
-  await action(proxyReference, { ...options, network, txParams });
+  await action(proxyReference, { ...options, network, txParams, promptedNetwork });
   if (!options.dontExitProcess && process.env.NODE_ENV !== 'test') process.exit(0);
 }
 
@@ -80,6 +77,22 @@ async function action(proxyReference: string, options: any): Promise<void> {
     ...parsedContractReference,
     ...initMethodParams,
   } as UpdateParams);
+
+  const projectFile = new ProjectFile();
+  const networkFile = new NetworkFile(projectFile, network);
+
+  const proxies = networkFile.getProxies({
+    package: parsedContractReference.packageName ?? (parsedContractReference.contractAlias && projectFile.name),
+    contract: parsedContractReference.contractAlias,
+    address: parsedContractReference.proxyAddress,
+    kind: ProxyType.Upgradeable,
+  });
+
+  await push.runActionIfNeeded(uniq(proxies.map(proxy => proxy.contract)), network, {
+    ...options,
+    network: options.promptedNetwork,
+  });
+
   await Telemetry.report('update', { ...args, network, txParams }, interactive);
   await update({ ...args, network, txParams });
 }


### PR DESCRIPTION
Fixes https://github.com/OpenZeppelin/openzeppelin-sdk/issues/1508. Fixes https://github.com/OpenZeppelin/openzeppelin-sdk/issues/1507.

This PR is going to `release/2.8` directly because the same fix is already implemented in the soon-to-be-merged #1497. In fact this change is mostly the same one found in https://github.com/OpenZeppelin/openzeppelin-sdk/commit/fc5926e96b9ba82c338c4b5fa8b3af2405866d59 of that PR.

There's a change that seems unrelated, making an argument into an array, but because `upgrade` can work on multiple contracts at once the way to obtain the contracts that need to be pushed gets us an array. I think in practice it will always be of length 1 but we can't be sure.

There are no tests in this PR because we currently have no tests for implicit commands like push is for update.