### PR TITLE
Fix truffle deployed information for dependency contracts

### DIFF
--- a/packages/cli/src/models/network/NetworkController.ts
+++ b/packages/cli/src/models/network/NetworkController.ts
@@ -840,7 +840,7 @@ export default class NetworkController {
 
   // Proxy model
   private async _updateTruffleDeployedInformation(contractAlias: string, implementation: Contract): Promise<void> {
-    const contractName = this.projectFile.normalizeContractAlias(contractAlias);
+    const contractName = this.projectFile.contract(contractAlias);
     if (contractName) {
       const path = Contracts.getLocalPath(contractName);
       const data = fs.readJsonSync(path);


### PR DESCRIPTION
Fixes https://github.com/OpenZeppelin/openzeppelin-sdk/issues/1516.

At some point we introduced the "normalize contract alias" function and I think we replaced most uses of `.contract()` for it because it was almost the same, but it differs in an important detail when the contract is not local, which was causing this issue.

No regression tests because unfortunately we don't have an existing test setup for truffle deployed information.