### PR TITLE
Use posix.relative() instead of path.relative()

### DIFF
--- a/packages/cli/src/models/compiler/solidity/SourcesGatherer.ts
+++ b/packages/cli/src/models/compiler/solidity/SourcesGatherer.ts
@@ -1,5 +1,5 @@
 import { Loggy } from '@openzeppelin/upgrades';
-import { dirname, isAbsolute, join, relative, resolve } from 'path';
+import { dirname, isAbsolute, join, resolve, posix } from 'path';
 import fs from 'fs';
 import { promisify } from 'util';
 import { getImports } from '../../../utils/solidity';
@@ -35,7 +35,7 @@ export async function gatherSources(rootContracts: string[], workingDir: string)
 
   for (const contract of rootContracts) {
     queue.push({
-      name: relative(workingDir, contract),
+      name: posix.relative(workingDir, contract),
       url: resolve(workingDir, contract),
       root: workingDir,
     });


### PR DESCRIPTION
fixed #1558 

in solc-js, file path is used as key to manage dependencies, the contract body is retrieved via file path, so if: `import "./Contract2.sol";` appears, solc-js will use "./Contract2.sol" to lookup the body of contract which need to be place into it.

but when we use path.relative() to handle file path, it will transform from "./Contract2.sol" to ".\Contract2.sol" then solc-js cannot find correct contract body, finally throw "File import callback not supported".

so path.posix.relative() should be used in this case to ensure file path follows POSIX rule for a key to index contract body.