### PR TITLE
fix for docs and help messages for args whitespace issue

### DIFF
--- a/packages/cli/src/commands/call.ts
+++ b/packages/cli/src/commands/call.ts
@@ -28,7 +28,7 @@ const register: (program: any) => any = program =>
     .description(description)
     .option('--to <to>', 'address of the contract that will receive the call')
     .option('--method <method>', `name of the method to execute in the contract`)
-    .option('--args <arg1, arg2, ...>', 'arguments to the method to execute')
+    .option('--args <arg1,arg2,...>', 'arguments to the method to execute')
     .withNetworkOptions()
     .withNonInteractiveOption()
     .action(action);

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -32,7 +32,7 @@ const register: (program: any) => any = program =>
     .usage('[contract] --network <network> [options]')
     .description(description)
     .option('--init [function]', `call function after creating contract. If none is given, 'initialize' will be used`)
-    .option('--args <arg1, arg2, ...>', 'provide initialization arguments for your contract if required')
+    .option('--args <arg1,arg2,...>', 'provide initialization arguments for your contract if required')
     .option('--force', 'ignore contracts validation errors')
     .option('--minimal', 'creates a cheaper but non-upgradeable instance instead, using a minimal proxy')
     .withNetworkOptions()

--- a/packages/cli/src/commands/create2.ts
+++ b/packages/cli/src/commands/create2.ts
@@ -31,7 +31,7 @@ const register: (program: any) => any = program =>
       '--init [function]',
       `initialization function to call after creating contract (defaults to 'initialize', skips initialization if not set)`,
     )
-    .option('--args <arg1, arg2, ...>', 'arguments to the initialization function')
+    .option('--args <arg1,arg2,...>', 'arguments to the initialization function')
     .option('--admin <admin>', "admin of the proxy (uses the project's proxy admin if not set)")
     .option(
       '--signature <signature>',

--- a/packages/cli/src/commands/send-tx.ts
+++ b/packages/cli/src/commands/send-tx.ts
@@ -28,7 +28,7 @@ const register: (program: any) => any = program =>
     .description(description)
     .option('--to <to>', 'address of the contract that will receive the transaction')
     .option('--method <method>', `name of the method to execute in the contract`)
-    .option('--args <arg1, arg2, ...>', 'arguments to the method to execute')
+    .option('--args <arg1,arg2,...>', 'arguments to the method to execute')
     .option('--value <value>', `optional value in wei to send with the transaction`)
     .option(
       '--gas <gas>',

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -35,7 +35,7 @@ const register: (program: any) => any = program =>
       '--init [function]',
       `call function after upgrading contract. If no name is given, 'initialize' will be used`,
     )
-    .option('--args <arg1, arg2, ...>', 'provide initialization arguments for your contract if required')
+    .option('--args <arg1,arg2,...>', 'provide initialization arguments for your contract if required')
     .option('--all', 'upgrade all contracts in the application')
     .option('--force', 'ignore contracts validation errors')
     .withNetworkOptions()


### PR DESCRIPTION
Had to fix this, because even a year later I ran into it. Fast 5 minute fix to docs and messages.

Fixes https://github.com/OpenZeppelin/openzeppelin-sdk/issues/1574. Fixes https://github.com/OpenZeppelin/openzeppelin-sdk/issues/783.

Happy to edit and include a note on ensuring no whitespace either. May be helpful to newer users.